### PR TITLE
fix(ui): dark-mode hover, platform-aware Cmd/Ctrl+K, palette animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,12 @@
 @plugin "tailwindcss-animate";
 @plugin "@tailwindcss/typography";
 
+/* next-themes uses `attribute="class"` (toggles a `.dark` class on <html>).
+   Tailwind v4's default `dark:` variant follows `prefers-color-scheme`,
+   which decouples from the active theme class. Pin it to the `.dark`
+   class so `dark:` utilities track the site theme, not the OS setting. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* Fix: Chrome 120+ changed <details> to use ::details-content pseudo-element
    with content-visibility:hidden. The old md:!block trick no longer works.
    Force details content visible on desktop so CollapsibleSection works. */

--- a/app/login/_content.tsx
+++ b/app/login/_content.tsx
@@ -76,7 +76,7 @@ export function LoginContent() {
       <div className="space-y-3">
         <button
           onClick={() => signInWithGitHub(nextPath)}
-          className="w-full flex items-center justify-center gap-3 px-6 py-3 border border-border text-foreground font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+          className="w-full flex items-center justify-center gap-3 px-6 py-3 border border-border text-foreground font-medium cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
         >
           <Github className="w-5 h-5" />
           {t("auth.signInWithGitHub")}
@@ -84,7 +84,7 @@ export function LoginContent() {
 
         <button
           onClick={() => signInWithLinuxDo(nextPath)}
-          className="w-full flex items-center justify-center gap-3 px-6 py-3 border border-border text-foreground font-medium hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+          className="w-full flex items-center justify-center gap-3 px-6 py-3 border border-border text-foreground font-medium cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
         >
           <LogIn className="w-5 h-5" />
           {t("auth.signInWithLinuxDo")}

--- a/app/styles/data-dense/showcase/_content.tsx
+++ b/app/styles/data-dense/showcase/_content.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useEffect } from "react";
 import Link from "next/link";
+import { ShortcutHint } from "@/lib/platform/shortcut-hint";
 
 // ─── Hooks ────────────────────────────────────────────────────────────────────
 
@@ -510,18 +511,18 @@ export default function DataDenseShowcaseContent() {
               <p className="text-xs font-semibold text-[#1e293b] mb-2">Keyboard Shortcuts</p>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-1.5">
                 {[
-                  { keys: "Ctrl+K", desc: "Search" },
-                  { keys: "Ctrl+N", desc: "New record" },
-                  { keys: "Ctrl+S", desc: "Save" },
-                  { keys: "Ctrl+/", desc: "Help" },
-                  { keys: "Esc", desc: "Close modal" },
-                  { keys: "J / K", desc: "Navigate rows" },
-                  { keys: "E", desc: "Edit selected" },
-                  { keys: "Del", desc: "Delete selected" },
+                  { keys: "K", desc: "Search", mod: true },
+                  { keys: "N", desc: "New record", mod: true },
+                  { keys: "S", desc: "Save", mod: true },
+                  { keys: "/", desc: "Help", mod: true },
+                  { keys: "Esc", desc: "Close modal", mod: false },
+                  { keys: "J / K", desc: "Navigate rows", mod: false },
+                  { keys: "E", desc: "Edit selected", mod: false },
+                  { keys: "Del", desc: "Delete selected", mod: false },
                 ].map((shortcut) => (
                   <div key={shortcut.keys} className="flex items-center gap-2">
                     <kbd className="px-1.5 py-0.5 text-[10px] font-mono bg-[#f8fafc] border border-[#e2e8f0] rounded text-[#64748b]">
-                      {shortcut.keys}
+                      {shortcut.mod ? <ShortcutHint keys={shortcut.keys} /> : shortcut.keys}
                     </kbd>
                     <span className="text-[10px] text-[#94a3b8]">{shortcut.desc}</span>
                   </div>

--- a/app/styles/linear-style/showcase/_content.tsx
+++ b/app/styles/linear-style/showcase/_content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
+import { ShortcutHint } from "@/lib/platform/shortcut-hint";
 
 /* ------------------------------------------------------------------ */
 /*  useInView hook                                                      */
@@ -403,7 +404,7 @@ export default function ShowcaseContent() {
           >
             <SearchIcon className="w-3.5 h-3.5 text-zinc-500" />
             <span className="text-xs text-zinc-500">Search...</span>
-            <Kbd>&#8984;K</Kbd>
+            <Kbd><ShortcutHint keys="K" /></Kbd>
           </button>
         </div>
       </header>
@@ -445,7 +446,7 @@ export default function ShowcaseContent() {
                 className="px-5 py-2.5 border border-white/10 bg-white/[0.03] text-zinc-300 text-sm font-medium rounded-lg hover:bg-white/[0.06] transition-colors duration-150 flex items-center gap-2"
               >
                 <span>Quick start</span>
-                <Kbd>&#8984;K</Kbd>
+                <Kbd><ShortcutHint keys="K" /></Kbd>
               </button>
             </div>
           </div>

--- a/app/styles/notion-style/showcase/_content.tsx
+++ b/app/styles/notion-style/showcase/_content.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
+import { ShortcutHint } from "@/lib/platform/shortcut-hint";
 
 /* ------------------------------------------------------------------ */
 /*  useInView hook                                                      */
@@ -524,7 +525,7 @@ export default function NotionStyleShowcase() {
                 <path d="M10.5 10.5l-2-2" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
               </svg>
               Search
-              <span className="ml-auto text-[10px] text-[#37352f]/30">⌘K</span>
+              <span className="ml-auto text-[10px] text-[#37352f]/30"><ShortcutHint keys="K" /></span>
             </button>
 
             {/* Favorites section */}

--- a/app/templates/anx-blog/page.tsx
+++ b/app/templates/anx-blog/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = "force-static";
 
 import { useMemo, useState, useEffect, type CSSProperties, type FormEvent } from "react";
 import Link from "next/link";
+import { ShortcutHint } from "@/lib/platform/shortcut-hint";
 import {
   ArrowRight,
   Command,
@@ -657,7 +658,7 @@ export default function AnxBlogTemplate() {
                 className="ml-1 inline-flex items-center gap-2 border-2 border-black bg-zinc-100 px-3 py-2 text-xs font-bold shadow-[2px_2px_0_#000] transition-colors hover:bg-black hover:text-white"
               >
                 <Command className="h-4 w-4" />
-                <span>CMD+K</span>
+                <span><ShortcutHint keys="K" /></span>
               </button>
             </div>
 

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -13,6 +13,7 @@ import {
   isChangelogPath,
   markLatestChangelogSeen,
 } from "@/lib/changelog/read-state";
+import { ShortcutHint } from "@/lib/platform/shortcut-hint";
 import { ChevronDown } from "lucide-react";
 import { GitHubStarButton } from "@/components/github-star-button";
 import { trackEvent } from "@/lib/analytics/events";
@@ -414,7 +415,7 @@ export function Header() {
                 <path d="m21 21-4.3-4.3" />
               </svg>
               <span className="hidden xl:inline">{t("nav.search")}</span>
-              <kbd className="hidden 2xl:inline-flex rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">Ctrl K</kbd>
+              <kbd className="hidden 2xl:inline-flex rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"><ShortcutHint keys="K" separator=" " /></kbd>
             </button>
 
             {/* Main Nav Items: link or dropdown trigger */}

--- a/components/ui/command-palette.tsx
+++ b/components/ui/command-palette.tsx
@@ -168,7 +168,7 @@ export function CommandPalette() {
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content
-          className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2 bg-background shadow-surface-lg rounded-lg overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]"
+          className="fixed top-[20%] left-0 right-0 mx-auto w-full max-w-lg z-50 bg-background shadow-surface-lg rounded-lg overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
           onKeyDown={handleKeyDown}
           onOpenAutoFocus={(e) => {
             // Take over focus management so we can target the search

--- a/lib/platform/shortcut-hint.tsx
+++ b/lib/platform/shortcut-hint.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const APPLE_PLATFORM_RE = /Mac|iPhone|iPad|iPod/i;
+
+interface ShortcutHintProps {
+  /** Key label that follows the modifier, e.g. "K", "N", "S", "/" */
+  keys: string;
+  /**
+   * Separator inserted between "Ctrl" and `keys` on non-Apple platforms.
+   * Apple platforms always render "⌘" directly adjacent to `keys` (no
+   * separator), matching macOS convention. Default "+".
+   */
+  separator?: string;
+}
+
+/**
+ * Platform-aware keyboard shortcut text. Renders "⌘{keys}" on Apple platforms
+ * (macOS / iOS / iPadOS) and "Ctrl{separator}{keys}" elsewhere.
+ *
+ * SSR-safe: returns the non-Apple variant during SSR and the first client
+ * render so the server and client markup match (no hydration mismatch), then
+ * settles to the real value after mount. Wrap in a <kbd>/<span> for styling.
+ */
+export function ShortcutHint({ keys, separator = "+" }: ShortcutHintProps) {
+  const [isApple, setIsApple] = useState(false);
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    setIsApple(APPLE_PLATFORM_RE.test(navigator.platform || navigator.userAgent));
+  }, []);
+  return <>{isApple ? `\u2318${keys}` : `Ctrl${separator}${keys}`}</>;
+}


### PR DESCRIPTION
## Summary

Three related UI polish fixes bundled in one PR:

- **Dark-mode hover leak (project-wide):** Tailwind v4's default `dark:` variant follows `prefers-color-scheme`, not the `.dark` class managed by `next-themes` (`attribute="class"`). When a visitor's OS was dark but the site was set to light, `dark:` utilities still applied — e.g. the login auth buttons turned dark on hover in light theme. Pinned `dark:` to the `.dark` class via `@custom-variant dark` in `globals.css` (fixes every `dark:` usage site, not just login). Also bumped the login buttons' hover bg from `zinc-50` (identical to page background — invisible) to `zinc-100`, and added `cursor-pointer`.
- **Platform-aware Cmd/Ctrl+K hints:** The shortcut hint text was hardcoded ("Ctrl K" / "CMD+K" / "⌘K") across the header, templates, and style showcases, so macOS users saw "Ctrl" and Windows users saw "⌘". The keydown handlers already accept `metaKey || ctrlKey`, so only the display needed adapting. Added a self-contained, SSR-safe `<ShortcutHint>` component (`lib/platform/shortcut-hint.tsx`) that detects Apple platforms via `navigator.platform || navigator.userAgent` and renders `⌘K` there, `Ctrl K` elsewhere. Replaced 6 hardcoded hint spots.
- **Command palette animation:** The Cmd/Ctrl+K palette visibly slid in from the upper-left to center instead of appearing from the center. Root cause: transform-based centering (`left-1/2 -translate-x-1/2`) combined with `slide-in-from-*` compensation that was miscalibrated for the palette's `top-[20%]` position. Re-centered horizontally without transform (`left-0 right-0 mx-auto`) and dropped the slide classes; the palette now fades + zoom-scales in place from the center.

## Test plan

- [ ] Light theme, OS dark: hover the two login buttons (`/login`) — background stays light (no dark hover leak); hover is a visible light gray; cursor is a pointer.
- [ ] Dark theme: hover the login buttons — `zinc-800` hover still works.
- [ ] macOS Safari/Chrome: header search button shows `⌘K`; open palette with `Cmd+K`.
- [ ] Windows/Linux: header search button shows `Ctrl K`; open palette with `Ctrl+K`.
- [ ] Style showcases (Linear / Notion / data-dense) and ANX blog template: shortcut hints adapt to platform.
- [ ] Open the command palette: it fades + scales in from the center, no upper-left slide.
- [ ] `pnpm typecheck` passes (no type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcut hints now adapt to Mac or Windows/Linux conventions across search and navigation controls.
  * Dark mode utilities now consistently follow the active theme selection.
* **Bug Fixes**
  * Improved command palette positioning for more reliable centering.
  * Refined command palette transitions for a smoother, less distracting experience.
  * Updated login button hover states and pointer behavior for clearer interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->