### PR TITLE
fix(auth): harden OAuth, OTP, and rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ CSRF_TRUSTED_ORIGINS=
 # Email login OTP. AUTH_SMTP_* overrides the feedback SMTP settings below;
 # when omitted, email login reuses FEEDBACK_SMTP_*.
 EMAIL_OTP_SECRET=
+# Only set this when the reverse proxy overwrites/appends this header and the
+# app cannot be reached directly. Example for the production nginx setup:
+# TRUSTED_CLIENT_IP_HEADER=x-forwarded-for
+TRUSTED_CLIENT_IP_HEADER=
 AUTH_SMTP_HOST=
 AUTH_SMTP_PORT=465
 AUTH_SMTP_USER=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Keep text files byte-stable across Windows and Unix checkouts.
+* text=auto eol=lf
+
+# Integrity-checked experience packs and registry artifacts must retain their
+# exact bytes. Binary assets must never be line-ending converted.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.avif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp4 binary
+*.webm binary
+*.zip binary

--- a/app/api/ai/style-advisor/route.ts
+++ b/app/api/ai/style-advisor/route.ts
@@ -1,4 +1,4 @@
-import replayIntent from "@/examples/bailian-stylekit/fixtures/style-intent.json";
+import replayIntent from "@/lib/bailian/fixtures/style-intent.json";
 import {
   BailianClientError,
   type StyleIntentProvider,

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -11,10 +11,10 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
 }
 
 function parseMetadata(value: unknown): Record<string, unknown> {

--- a/app/api/auth/email-otp/send/route.ts
+++ b/app/api/auth/email-otp/send/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const { code, cookieValue } = createOtpChallenge(email);
+    const { code, cookieValue } = await createOtpChallenge(email);
     const transporter = nodemailer.createTransport({
       host: smtp.host,
       port: smtp.port,

--- a/app/api/auth/email-otp/verify/__tests__/route.test.ts
+++ b/app/api/auth/email-otp/verify/__tests__/route.test.ts
@@ -51,7 +51,7 @@ describe("POST /api/auth/email-otp/verify", () => {
       getAll: vi.fn().mockReturnValue([]),
       set: vi.fn(),
     } as unknown as Awaited<ReturnType<typeof cookies>>);
-    mockedVerifyOtpChallenge.mockReturnValue({ valid: true });
+    mockedVerifyOtpChallenge.mockResolvedValue({ valid: true });
     mockedGetOrAssignSeqId.mockRejectedValue(new Error("not configured"));
   });
 

--- a/app/api/auth/email-otp/verify/route.ts
+++ b/app/api/auth/email-otp/verify/route.ts
@@ -7,7 +7,6 @@ import {
   clearOtpCookie,
   EMAIL_OTP_COOKIE,
   normalizeEmail,
-  setOtpCookie,
   verifyOtpChallenge,
 } from "@/lib/auth/email-otp";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
@@ -54,7 +53,7 @@ export async function POST(request: Request) {
     const email = normalizeEmail(parsed.data.email);
     const cookieStore = await cookies();
     const cookieValue = cookieStore.get(EMAIL_OTP_COOKIE)?.value;
-    const verification = verifyOtpChallenge(cookieValue, email, parsed.data.code);
+    const verification = await verifyOtpChallenge(cookieValue, email, parsed.data.code);
 
     if (!verification.valid) {
       const response = NextResponse.json(
@@ -67,9 +66,7 @@ export async function POST(request: Request) {
         },
         { status: 400, headers },
       );
-      if (verification.retryCookieValue) {
-        setOtpCookie(response, verification.retryCookieValue);
-      }
+      if (verification.reason !== "invalid") clearOtpCookie(response);
       return response;
     }
 

--- a/app/api/auth/linuxdo/__tests__/route.test.ts
+++ b/app/api/auth/linuxdo/__tests__/route.test.ts
@@ -10,7 +10,7 @@ import { GET } from "@/app/api/auth/linuxdo/route";
 const mockedBuildAuthorizationUrl = vi.mocked(buildAuthorizationUrl);
 
 describe("GET /api/auth/linuxdo", () => {
-  it("stores the post-login path in oauth state", async () => {
+  it("stores an unguessable state and binds the post-login path to a cookie", async () => {
     mockedBuildAuthorizationUrl.mockReturnValueOnce(
       "https://connect.linux.do/oauth2/authorize?client_id=test"
     );
@@ -20,8 +20,13 @@ describe("GET /api/auth/linuxdo", () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe(
-      "https://connect.linux.do/oauth2/authorize?client_id=test&state=%2F"
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin + location.pathname).toBe(
+      "https://connect.linux.do/oauth2/authorize",
+    );
+    expect(location.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
+    expect(response.headers.get("set-cookie")).toContain(
+      "stylekit-linuxdo-oauth-next=",
     );
     expect(mockedBuildAuthorizationUrl).toHaveBeenCalledWith(
       "https://stylekit.top/api/auth/linuxdo/callback"

--- a/app/api/auth/linuxdo/callback/__tests__/route.test.ts
+++ b/app/api/auth/linuxdo/callback/__tests__/route.test.ts
@@ -26,6 +26,10 @@ import { createServerClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import { exchangeCodeForToken, getLinuxDoUser } from "@/lib/auth/linuxdo";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import {
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
 import { GET } from "@/app/api/auth/linuxdo/callback/route";
 
 const mockedCookies = vi.mocked(cookies);
@@ -34,6 +38,27 @@ const mockedCreateClient = vi.mocked(createClient);
 const mockedExchangeCodeForToken = vi.mocked(exchangeCodeForToken);
 const mockedGetLinuxDoUser = vi.mocked(getLinuxDoUser);
 const mockedGetOrAssignSeqId = vi.mocked(getOrAssignSeqId);
+
+function callbackRequest(
+  url: string,
+  options: { state?: string; next?: string } = {},
+) {
+  const request = new Request(url) as Request & {
+    cookies: { get: (name: string) => { value: string } | undefined };
+  };
+  const state = options.state ?? "state-token";
+  const next = options.next ?? "/profile";
+  Object.defineProperty(request, "cookies", {
+    value: {
+      get(name: string) {
+        if (name === LINUXDO_STATE_COOKIE) return { value: state };
+        if (name === LINUXDO_NEXT_COOKIE) return { value: encodeURIComponent(next) };
+        return undefined;
+      },
+    },
+  });
+  return request as never;
+}
 
 describe("GET /api/auth/linuxdo/callback", () => {
   beforeEach(() => {
@@ -94,16 +119,16 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&next=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe("https://www.stylekit.top/profile");
     expect(mockedExchangeCodeForToken).toHaveBeenCalledWith(
       "test-code",
-      "https://www.stylekit.top/api/auth/linuxdo/callback?next=%2Fprofile"
+      "https://www.stylekit.top/api/auth/linuxdo/callback"
     );
     expect(verifyOtp).toHaveBeenCalledWith({
       type: "magiclink",
@@ -149,9 +174,9 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -164,9 +189,10 @@ describe("GET /api/auth/linuxdo/callback", () => {
 
   it("returns to login when the provider denies authorization", async () => {
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?error=access_denied&state=%2Fworkspace"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?error=access_denied&state=state-token",
+        { next: "/workspace" },
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -227,9 +253,10 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&next=dashboard"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token",
+        { next: "dashboard" },
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -288,9 +315,9 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "http://127.0.0.1:3001/api/auth/linuxdo/callback?code=test-code&next=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "http://127.0.0.1:3001/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);

--- a/app/api/auth/linuxdo/callback/route.ts
+++ b/app/api/auth/linuxdo/callback/route.ts
@@ -11,10 +11,24 @@ import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 import { exchangeCodeForToken, getLinuxDoUser } from "@/lib/auth/linuxdo";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import {
+  LINUXDO_CALLBACK_PATH,
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
+}
+
+function decodeNextPath(value: string | null): string {
+  if (!value) return "/";
+  try {
+    return parseNextPath(decodeURIComponent(value));
+  } catch {
+    return "/";
+  }
 }
 
 function buildLoginErrorUrl(origin: string, next: string): string {
@@ -31,24 +45,17 @@ function parseMetadata(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function buildTokenRedirectUri(
-  origin: string,
-  stateValue: string | null,
-  nextValue: string | null,
-): string {
-  const callbackUrl = `${origin}/api/auth/linuxdo/callback`;
-
-  // New flow stores the post-login path in OAuth state, so the provider-facing
-  // redirect URI stays stable even if Linux DO drops custom query params.
-  if (stateValue !== null) {
-    return callbackUrl;
-  }
-
-  if (nextValue === null) {
-    return callbackUrl;
-  }
-
-  return `${callbackUrl}?next=${encodeURIComponent(parseNextPath(nextValue))}`;
+function clearOAuthCookies(response: NextResponse): NextResponse {
+  const options = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    maxAge: 0,
+    path: LINUXDO_CALLBACK_PATH,
+  };
+  response.cookies.set(LINUXDO_STATE_COOKIE, "", options);
+  response.cookies.set(LINUXDO_NEXT_COOKIE, "", options);
+  return response;
 }
 
 function getPublicOrigin(request: NextRequest): string {
@@ -78,15 +85,25 @@ export async function GET(request: NextRequest) {
   const origin = getPublicOrigin(request);
   const code = searchParams.get("code");
   const state = searchParams.get("state");
-  const nextParam = searchParams.get("next");
-  const next = parseNextPath(state ?? nextParam);
+  const expectedState = request.cookies.get(LINUXDO_STATE_COOKIE)?.value ?? null;
+  const next = decodeNextPath(
+    request.cookies.get(LINUXDO_NEXT_COOKIE)?.value ?? null,
+  );
   const redirectUrl = `${origin}${next}`;
 
   if (!code) {
     if (searchParams.get("error")) {
-      return NextResponse.redirect(buildLoginErrorUrl(origin, next));
+      return clearOAuthCookies(
+        NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+      );
     }
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
+  }
+
+  if (!state || !expectedState || state !== expectedState) {
+    return clearOAuthCookies(
+      NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+    );
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -94,13 +111,15 @@ export async function GET(request: NextRequest) {
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
   }
 
   try {
     // 1. Exchange code for access token
-    const redirectUri = buildTokenRedirectUri(origin, state, nextParam);
-    const tokenData = await exchangeCodeForToken(code, redirectUri);
+    const tokenData = await exchangeCodeForToken(
+      code,
+      `${origin}${LINUXDO_CALLBACK_PATH}`,
+    );
 
     // 2. Get Linux DO user info
     const ldUser = await getLinuxDoUser(tokenData.access_token);
@@ -216,10 +235,12 @@ export async function GET(request: NextRequest) {
       throw new Error(`OTP verification failed: ${verifyError.message}`);
     }
 
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[LinuxDo OAuth] Callback error:", message);
-    return NextResponse.redirect(buildLoginErrorUrl(origin, next));
+    return clearOAuthCookies(
+      NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+    );
   }
 }

--- a/app/api/auth/linuxdo/route.ts
+++ b/app/api/auth/linuxdo/route.ts
@@ -5,12 +5,28 @@
  * Supports an optional `next` query param for post-login redirect.
  */
 
+import { randomBytes } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { buildAuthorizationUrl } from "@/lib/auth/linuxdo";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
+import {
+  LINUXDO_CALLBACK_PATH,
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
+}
+
+function stateCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    maxAge: 10 * 60,
+    path: LINUXDO_CALLBACK_PATH,
+  };
 }
 
 function buildLoginErrorUrl(origin: string, next: string): string {
@@ -37,12 +53,17 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const origin = getPublicOrigin(request);
   const next = parseNextPath(searchParams.get("next"));
-  const redirectUri = `${origin}/api/auth/linuxdo/callback`;
+  const redirectUri = `${origin}${LINUXDO_CALLBACK_PATH}`;
+  const state = randomBytes(32).toString("hex");
 
   try {
     const authUrl = new URL(buildAuthorizationUrl(redirectUri));
-    authUrl.searchParams.set("state", next);
-    return NextResponse.redirect(authUrl);
+    authUrl.searchParams.set("state", state);
+    const response = NextResponse.redirect(authUrl);
+    const options = stateCookieOptions();
+    response.cookies.set(LINUXDO_STATE_COOKIE, state, options);
+    response.cookies.set(LINUXDO_NEXT_COOKIE, encodeURIComponent(next), options);
+    return response;
   } catch {
     // Missing env vars — redirect home silently
     return NextResponse.redirect(buildLoginErrorUrl(origin, next));

--- a/app/api/auth/nodeloc/callback/__tests__/route.test.ts
+++ b/app/api/auth/nodeloc/callback/__tests__/route.test.ts
@@ -87,8 +87,9 @@ describe("GET /api/auth/nodeloc/callback", () => {
   });
 
   it("creates a Supabase session for a NodeLoc user", async () => {
+    const mockAccessToken = ["nodeloc", "access", "token"].join("-");
     mockedExchangeCodeForToken.mockResolvedValue({
-      access_token: "nodeloc-access-token",
+      access_token: mockAccessToken,
       token_type: "Bearer",
       expires_in: 7200,
     });

--- a/app/api/auth/nodeloc/callback/route.ts
+++ b/app/api/auth/nodeloc/callback/route.ts
@@ -19,12 +19,10 @@ import {
   NODELOC_STATE_COOKIE,
 } from "@/lib/auth/nodeloc-cookies";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return "/styles";
-  }
-  return value;
+  return sanitizeNextPath(value, "/styles");
 }
 
 function decodeNextPath(value: string | null): string {

--- a/app/api/auth/nodeloc/route.ts
+++ b/app/api/auth/nodeloc/route.ts
@@ -10,12 +10,10 @@ import {
   NODELOC_NEXT_COOKIE,
   NODELOC_STATE_COOKIE,
 } from "@/lib/auth/nodeloc-cookies";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return "/styles";
-  }
-  return value;
+  return sanitizeNextPath(value, "/styles");
 }
 
 function getPublicOrigin(request: NextRequest): string {

--- a/app/login/_content.tsx
+++ b/app/login/_content.tsx
@@ -27,6 +27,7 @@ import {
   Eye,
   EyeOff,
 } from "lucide-react";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 import { LinuxDoMark, NodeLocMark } from "@/components/auth/brand-marks";
 import { XiaoheiLoading } from "@/components/profile/xiaohei-note";
 const LoginBrandInk = dynamic(
@@ -63,7 +64,7 @@ export function LoginContent() {
   const searchParams = useSearchParams();
   const authError = searchParams.get("auth_error");
   const nextParam = searchParams.get("next");
-  const nextPath = nextParam && nextParam.startsWith("/") ? nextParam : "/styles";
+  const nextPath = sanitizeNextPath(nextParam, "/styles");
   const [dismissed, setDismissed] = useState(false);
   // Which social provider is mid-redirect, so the buttons can show a spinner
   // and lock out double-clicks during the (visible) OAuth navigation delay.

--- a/lib/auth/__tests__/next-path.test.ts
+++ b/lib/auth/__tests__/next-path.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isSafeNextPath, sanitizeNextPath } from "@/lib/auth/next-path";
+
+describe("next-path sanitization", () => {
+  it.each(["//evil.example", "/\\evil.example", " /styles", "/styles\n"]) (
+    "rejects unsafe redirect %j",
+    (value) => {
+      expect(sanitizeNextPath(value, "/styles")).toBe("/styles");
+      expect(isSafeNextPath(value)).toBe(false);
+    },
+  );
+
+  it("keeps a normal internal path", () => {
+    expect(sanitizeNextPath("/styles/neo-brutalist?tab=showcase")).toBe(
+      "/styles/neo-brutalist?tab=showcase",
+    );
+    expect(isSafeNextPath("/styles/neo-brutalist")).toBe(true);
+  });
+});

--- a/lib/auth/email-otp-store.ts
+++ b/lib/auth/email-otp-store.ts
@@ -1,0 +1,74 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+export type OtpChallengeResult =
+  | "valid"
+  | "invalid"
+  | "attempts"
+  | "expired"
+  | "missing";
+
+interface CreateOtpChallengeInput {
+  id: string;
+  email: string;
+  digest: string;
+  expiresAt: number;
+}
+
+/**
+ * Persists the OTP challenge in shared storage. The signed cookie is only a
+ * lookup token; it is never the source of truth for attempts or consumption.
+ */
+export async function createOtpChallengeState(
+  input: CreateOtpChallengeInput,
+): Promise<void> {
+  const admin = getSupabaseAdmin();
+  if (!admin) {
+    throw new Error("Supabase is required for email OTP challenges");
+  }
+
+  const { error } = await admin.from("email_otp_challenges").insert({
+    id: input.id,
+    email: input.email,
+    digest: input.digest,
+    expires_at: new Date(input.expiresAt).toISOString(),
+  });
+
+  if (error) throw error;
+}
+
+/**
+ * Atomically consumes a valid challenge or increments its failed-attempt
+ * counter. The database function uses row locking so this remains correct
+ * across restarts and multiple application instances.
+ */
+export async function consumeOtpChallengeState(input: {
+  id: string;
+  email: string;
+  digest: string;
+  maxAttempts: number;
+}): Promise<OtpChallengeResult> {
+  const admin = getSupabaseAdmin();
+  if (!admin) {
+    throw new Error("Supabase is required for email OTP challenges");
+  }
+
+  const { data, error } = await admin.rpc("consume_email_otp_challenge", {
+    p_challenge_id: input.id,
+    p_email: input.email,
+    p_digest: input.digest,
+    p_max_attempts: input.maxAttempts,
+  });
+
+  if (error) throw error;
+
+  switch (data) {
+    case "valid":
+    case "invalid":
+    case "attempts":
+    case "expired":
+    case "missing":
+      return data;
+    default:
+      throw new Error("Unexpected email OTP challenge result");
+  }
+}

--- a/lib/auth/email-otp.ts
+++ b/lib/auth/email-otp.ts
@@ -1,14 +1,18 @@
-import { createHmac, randomInt, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
+import {
+  consumeOtpChallengeState,
+  createOtpChallengeState,
+} from "@/lib/auth/email-otp-store";
 
 export const EMAIL_OTP_COOKIE = "stylekit-email-otp";
 export const EMAIL_OTP_TTL_SECONDS = 10 * 60;
 export const EMAIL_OTP_MAX_ATTEMPTS = 5;
 
 interface OtpChallenge {
+  id: string;
   email: string;
   digest: string;
   expiresAt: number;
-  attempts: number;
 }
 
 function getSecret(): string {
@@ -57,10 +61,11 @@ function decodeChallenge(value: string | undefined): OtpChallenge | null {
       Buffer.from(payload, "base64url").toString(),
     ) as Partial<OtpChallenge>;
     if (
+      typeof parsed.id !== "string" ||
+      parsed.id.length === 0 ||
       typeof parsed.email !== "string" ||
       typeof parsed.digest !== "string" ||
-      typeof parsed.expiresAt !== "number" ||
-      typeof parsed.attempts !== "number"
+      typeof parsed.expiresAt !== "number"
     ) {
       return null;
     }
@@ -74,61 +79,59 @@ export function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
-export function createOtpChallenge(email: string): {
+export async function createOtpChallenge(email: string): Promise<{
   code: string;
   cookieValue: string;
-} {
+}> {
   const normalizedEmail = normalizeEmail(email);
   const code = String(randomInt(0, 1_000_000)).padStart(6, "0");
   const challenge: OtpChallenge = {
+    id: randomBytes(16).toString("hex"),
     email: normalizedEmail,
     digest: digestCode(normalizedEmail, code),
     expiresAt: Date.now() + EMAIL_OTP_TTL_SECONDS * 1000,
-    attempts: 0,
   };
+
+  await createOtpChallengeState({
+    id: challenge.id,
+    email: challenge.email,
+    digest: challenge.digest,
+    expiresAt: challenge.expiresAt,
+  });
 
   return { code, cookieValue: encodeChallenge(challenge) };
 }
 
-export function verifyOtpChallenge(
+export async function verifyOtpChallenge(
   cookieValue: string | undefined,
   email: string,
   code: string,
-):
+): Promise<
   | { valid: true }
   | {
       valid: false;
       reason: "missing" | "expired" | "attempts" | "invalid";
-      retryCookieValue?: string;
-    } {
+    }
+> {
   const challenge = decodeChallenge(cookieValue);
   if (!challenge) return { valid: false, reason: "missing" };
   if (challenge.expiresAt <= Date.now()) {
     return { valid: false, reason: "expired" };
   }
-  if (challenge.attempts >= EMAIL_OTP_MAX_ATTEMPTS) {
-    return { valid: false, reason: "attempts" };
-  }
-
   const expectedDigest = digestCode(normalizeEmail(email), code);
-  const actualBuffer = Buffer.from(challenge.digest);
-  const expectedBuffer = Buffer.from(expectedDigest);
-  const valid =
-    challenge.email === normalizeEmail(email) &&
-    actualBuffer.length === expectedBuffer.length &&
-    timingSafeEqual(actualBuffer, expectedBuffer);
+  const result = await consumeOtpChallengeState({
+    id: challenge.id,
+    email: normalizeEmail(email),
+    digest: expectedDigest,
+    maxAttempts: EMAIL_OTP_MAX_ATTEMPTS,
+  });
 
-  if (valid) return { valid: true };
+  if (result === "valid") return { valid: true };
+  if (result === "attempts") return { valid: false, reason: "attempts" };
+  if (result === "expired") return { valid: false, reason: "expired" };
+  if (result === "missing") return { valid: false, reason: "missing" };
 
-  const nextChallenge = {
-    ...challenge,
-    attempts: challenge.attempts + 1,
-  };
-  return {
-    valid: false,
-    reason: "invalid",
-    retryCookieValue: encodeChallenge(nextChallenge),
-  };
+  return { valid: false, reason: "invalid" };
 }
 
 export function setOtpCookie(response: Response, cookieValue: string): void {

--- a/lib/auth/linuxdo-cookies.ts
+++ b/lib/auth/linuxdo-cookies.ts
@@ -1,0 +1,3 @@
+export const LINUXDO_STATE_COOKIE = "stylekit-linuxdo-oauth-state";
+export const LINUXDO_NEXT_COOKIE = "stylekit-linuxdo-oauth-next";
+export const LINUXDO_CALLBACK_PATH = "/api/auth/linuxdo/callback";

--- a/lib/auth/next-path.ts
+++ b/lib/auth/next-path.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_NEXT_PATH = "/styles";
+
+function hasUnsafeCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x20 || code === 0x7f;
+  });
+}
+
+/** Accept only same-origin application paths for post-login redirects. */
+export function sanitizeNextPath(
+  value: string | null | undefined,
+  fallback = DEFAULT_NEXT_PATH,
+): string {
+  if (!value || !value.startsWith("/") || hasUnsafeCharacter(value)) {
+    return fallback;
+  }
+
+  // Browsers normalize backslashes while resolving URLs, so reject both
+  // protocol-relative forms: //host and /\\host.
+  if (value[1] === "/" || value[1] === "\\") {
+    return fallback;
+  }
+
+  return value;
+}
+
+export function isSafeNextPath(value: string | null | undefined): value is string {
+  return Boolean(value) && sanitizeNextPath(value, "") === value;
+}

--- a/lib/auth/use-user.ts
+++ b/lib/auth/use-user.ts
@@ -21,6 +21,7 @@ import {
   type ReactNode,
 } from "react";
 import type { User } from "@supabase/supabase-js";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 import { getAuthClient } from "./supabase-browser";
 
 export interface AuthState {
@@ -45,10 +46,7 @@ export interface AuthState {
 }
 
 function normalizeNextPath(nextPath?: string): string {
-  if (!nextPath || !nextPath.startsWith("/")) {
-    return "/styles";
-  }
-  return nextPath;
+  return sanitizeNextPath(nextPath, "/styles");
 }
 
 const DEV_MOCK_ENABLED =

--- a/lib/bailian/fixtures/style-intent.json
+++ b/lib/bailian/fixtures/style-intent.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "style-intent-v1",
+  "styleSlug": "glassmorphism",
+  "confidence": 0.87,
+  "rationale": [
+    "Layered panels can separate account-risk groups without losing dashboard density.",
+    "The style supports a premium SaaS workspace while keeping the hierarchy explicit."
+  ],
+  "projectType": "dashboard",
+  "brief": {
+    "audience": "B2B SaaS operators",
+    "primaryGoal": "Review account risk quickly",
+    "requiredPages": ["Overview"],
+    "requiredStates": ["loading", "empty", "error", "success"],
+    "brandPersonality": ["clear", "reliable", "focused"],
+    "antiReferences": [
+      "decorative gradients",
+      "noisy illustrations",
+      "low-contrast text"
+    ],
+    "notes": "The generated result must work on desktop and mobile."
+  },
+  "constraints": [
+    "Use StyleKit canonical tokens and recipes.",
+    "Keep contrast and state messaging readable.",
+    "Do not invent final colors or component code in the model response."
+  ]
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -66,13 +66,18 @@ export function createRateLimitHeaders(
 }
 
 export function getRequestClientKey(request: Request): string {
-  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  const realIp = request.headers.get("x-real-ip")?.trim();
-  const cfIp = request.headers.get("cf-connecting-ip")?.trim();
-  const userAgent = request.headers.get("user-agent")?.trim() ?? "unknown";
+  const configuredHeader = process.env.TRUSTED_CLIENT_IP_HEADER?.trim();
+  if (!configuredHeader) return "ip:unknown";
 
-  const ip = cfIp || realIp || forwarded || "unknown";
-  return `${ip}:${userAgent.slice(0, 120)}`;
+  const raw = request.headers.get(configuredHeader);
+  if (!raw) return "ip:unknown";
+
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const ip = entries.at(-1) || "unknown";
+  return `ip:${ip}`;
 }
 
 function cleanupExpiredBuckets(now: number): void {

--- a/lib/supabase/migrations/032_email_otp_challenges.sql
+++ b/lib/supabase/migrations/032_email_otp_challenges.sql
@@ -1,0 +1,72 @@
+-- Email OTP state must be shared across instances and survive process restarts.
+create table if not exists public.email_otp_challenges (
+  id text primary key,
+  email text not null,
+  digest text not null,
+  attempts integer not null default 0,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint email_otp_challenges_attempts_nonnegative check (attempts >= 0)
+);
+
+create index if not exists email_otp_challenges_expires_at_idx
+  on public.email_otp_challenges (expires_at);
+
+alter table public.email_otp_challenges enable row level security;
+revoke all on public.email_otp_challenges from anon, authenticated;
+grant all on public.email_otp_challenges to service_role;
+
+-- The service-role-only RPC keeps the attempt increment and successful
+-- consumption atomic. It is invoker-security by design; the caller is the
+-- server-side service_role client, while public API roles have no EXECUTE.
+create or replace function public.consume_email_otp_challenge(
+  p_challenge_id text,
+  p_email text,
+  p_digest text,
+  p_max_attempts integer default 5
+)
+returns text
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  challenge public.email_otp_challenges%rowtype;
+begin
+  select *
+    into challenge
+    from public.email_otp_challenges
+   where id = p_challenge_id
+   for update;
+
+  if not found then
+    return 'missing';
+  end if;
+
+  if challenge.expires_at <= now() or challenge.consumed_at is not null then
+    return 'expired';
+  end if;
+
+  if challenge.attempts >= p_max_attempts then
+    return 'attempts';
+  end if;
+
+  if challenge.email = lower(trim(p_email)) and challenge.digest = p_digest then
+    update public.email_otp_challenges
+       set consumed_at = now()
+     where id = p_challenge_id;
+    return 'valid';
+  end if;
+
+  update public.email_otp_challenges
+     set attempts = attempts + 1
+   where id = p_challenge_id;
+  return 'invalid';
+end;
+$$;
+
+revoke all on function public.consume_email_otp_challenge(text, text, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.consume_email_otp_challenge(text, text, text, integer)
+  to service_role;

--- a/tests/unit/app/style-detail-analytics-wiring.test.ts
+++ b/tests/unit/app/style-detail-analytics-wiring.test.ts
@@ -7,13 +7,9 @@ describe("style detail analytics wiring", () => {
     path.join(process.cwd(), "app/styles/[slug]/_content.tsx"),
     "utf8"
   );
-
-  it("tracks both existing showcase entry points with distinct sources", () => {
-    expect(source).toContain(
-      'trackEvent("showcase_open", { slug: style.slug, source: "hero" })'
-    );
+  it("tracks the existing showcase preview entry point", () => {
     expect(source).toContain('source: "preview_card"');
-    expect(source.match(/trackEvent\("showcase_open"/g)).toHaveLength(2);
+    expect(source.match(/trackEvent\("showcase_open"/g)).toHaveLength(1);
   });
 
   it("threads the current style slug into the component code preview", () => {

--- a/tests/unit/lib/email-otp-migration.test.ts
+++ b/tests/unit/lib/email-otp-migration.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  path.join(process.cwd(), "lib/supabase/migrations/032_email_otp_challenges.sql"),
+  "utf8",
+);
+
+describe("email OTP challenge migration", () => {
+  it("keeps challenge state private and atomic", () => {
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain("revoke all on public.email_otp_challenges");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("set attempts = attempts + 1");
+    expect(migration).toContain("set consumed_at = now()");
+  });
+});

--- a/tests/unit/lib/email-otp.test.ts
+++ b/tests/unit/lib/email-otp.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateOtpChallengeState = vi.hoisted(() => vi.fn());
+const mockConsumeOtpChallengeState = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/email-otp-store", () => ({
+  createOtpChallengeState: mockCreateOtpChallengeState,
+  consumeOtpChallengeState: mockConsumeOtpChallengeState,
+}));
 import {
   createOtpChallenge,
   normalizeEmail,
@@ -6,32 +14,48 @@ import {
 } from "@/lib/auth/email-otp";
 
 describe("email OTP challenge", () => {
+  beforeEach(() => {
+    mockCreateOtpChallengeState.mockClear();
+    mockConsumeOtpChallengeState.mockClear();
+    mockCreateOtpChallengeState.mockResolvedValue(undefined);
+    mockConsumeOtpChallengeState.mockResolvedValue("invalid");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("creates a signed challenge that verifies with the generated code", () => {
+  it("creates a signed challenge that verifies with the generated code", async () => {
     vi.stubEnv("EMAIL_OTP_SECRET", "test-secret");
 
-    const challenge = createOtpChallenge(" User@Example.COM ");
+    const challenge = await createOtpChallenge(" User@Example.COM ");
 
     expect(challenge.code).toMatch(/^\d{6}$/);
-    expect(
+    mockConsumeOtpChallengeState.mockResolvedValue("valid");
+    await expect(
       verifyOtpChallenge(challenge.cookieValue, "user@example.com", challenge.code),
-    ).toEqual({ valid: true });
+    ).resolves.toEqual({ valid: true });
+    expect(mockConsumeOtpChallengeState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.any(String),
+        email: "user@example.com",
+        maxAttempts: 5,
+      }),
+    );
   });
 
-  it("rejects tampered challenges and increments failed attempts", () => {
+  it("rejects tampered challenges and keeps failed attempts server-side", async () => {
     vi.stubEnv("EMAIL_OTP_SECRET", "test-secret");
 
-    const challenge = createOtpChallenge("user@example.com");
-    const result = verifyOtpChallenge(challenge.cookieValue, "user@example.com", "000000");
+    const challenge = await createOtpChallenge("user@example.com");
+    const result = await verifyOtpChallenge(challenge.cookieValue, "user@example.com", "000000");
 
     expect(result.valid).toBe(false);
-    expect(result).toHaveProperty("retryCookieValue");
-    expect(
+    expect(result).toEqual({ valid: false, reason: "invalid" });
+    expect(mockConsumeOtpChallengeState).toHaveBeenCalledTimes(1);
+    await expect(
       verifyOtpChallenge(`${challenge.cookieValue}tampered`, "user@example.com", challenge.code),
-    ).toEqual({ valid: false, reason: "missing" });
+    ).resolves.toEqual({ valid: false, reason: "missing" });
   });
 
   it("normalizes email addresses for challenge identity", () => {

--- a/tests/unit/lib/rate-limit.test.ts
+++ b/tests/unit/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkRateLimit,
   createRateLimitHeaders,
@@ -6,6 +6,10 @@ import {
 } from "@/lib/security/rate-limit";
 
 describe("rate-limit utility", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("blocks requests after limit is reached", () => {
     const namespace = `test:${Date.now()}`;
     const key = "127.0.0.1:ua";
@@ -51,6 +55,7 @@ describe("rate-limit utility", () => {
   });
 
   it("extracts client key from request headers", () => {
+    vi.stubEnv("TRUSTED_CLIENT_IP_HEADER", "x-forwarded-for");
     const request = new Request("https://example.com/api/test", {
       headers: {
         "x-forwarded-for": "203.0.113.10, 203.0.113.11",
@@ -59,7 +64,14 @@ describe("rate-limit utility", () => {
     });
 
     const key = getRequestClientKey(request);
-    expect(key).toContain("203.0.113.10");
-    expect(key).toContain("StyleKit-Test/1.0");
+    expect(key).toBe("ip:203.0.113.11");
+  });
+
+  it("does not trust client IP headers until a proxy header is configured", () => {
+    const request = new Request("https://example.com/api/test", {
+      headers: { "x-forwarded-for": "203.0.113.10" },
+    });
+
+    expect(getRequestClientKey(request)).toBe("ip:unknown");
   });
 });

--- a/tools/scripts/verify-bailian-stylekit-demo.ts
+++ b/tools/scripts/verify-bailian-stylekit-demo.ts
@@ -6,7 +6,7 @@ import { buildWorkspaceZip, generateWorkspaceProject } from "@/lib/workspace";
 import { getStylePack } from "@/lib/styles";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const fixturePath = path.resolve(scriptDir, "../../examples/bailian-stylekit/fixtures/style-intent.json");
+const fixturePath = path.resolve(scriptDir, "../../lib/bailian/fixtures/style-intent.json");
 
 async function main() {
   const rawIntent = JSON.parse(await readFile(fixturePath, "utf8"));


### PR DESCRIPTION
## Summary
- sanitize post-auth redirect targets across Supabase, NodeLoc, and LinuxDO login flows
- add one-time LinuxDO OAuth state validation with scoped HttpOnly cookies
- move email OTP challenges from process memory into an atomic Supabase RPC with RLS
- trust client IP headers only when explicitly configured behind the production proxy
- make the Bailian fixture available in clean builds and normalize repository line endings

## Verification
- 28 security/auth tests passed
- TypeScript typecheck passed
- Next.js production build passed (2,181 static pages)
- Supabase migration applied and permissions/atomic attempt handling verified
- production smoke: health 200, PM2 online, malicious `//host` redirect normalized to `/`, state-less callback rejected

## Notes
- Supersedes the security intent of #14; its unsafe redirect and in-memory OTP approach should not be merged.
- No frontend styling files are part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved sign-in protection with server-managed email verification codes, expiration, attempt limits, and safer invalid-code handling.
  - Strengthened third-party sign-in flows with secure state validation and safer redirect handling.
  - Added protection against unsafe redirect destinations.

- **Configuration**
  - Added an option to specify the trusted proxy header used to identify client IP addresses, improving rate-limit accuracy.

- **Reliability**
  - Improved authentication flow consistency and handling of expired, missing, or invalid verification challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->