### PR TITLE
fix(analytics): cap Supabase analytics growth

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -94,6 +94,23 @@ export async function POST(request: Request) {
     const body = parsedBody.data;
     const internalPayload = parseClientAnalyticsPayload(body);
     if (internalPayload.success) {
+      // Catalog impressions are high-volume passive telemetry. Keep them in
+      // Vercel Analytics, but do not persist every card exposure in Postgres.
+      // This protects the database quota without changing user-facing behavior.
+      if (internalPayload.data.eventType === "catalog_impression") {
+        const catalogStyleSlug = readEventStyleSlug(
+          internalPayload.data.eventType,
+          internalPayload.data.eventData,
+        );
+        if (catalogStyleSlug && !(await resolveStyleBySlug(catalogStyleSlug))) {
+          return NextResponse.json(
+            { success: false, error: "Unknown style slug" },
+            { status: 400, headers: rateLimitHeaders },
+          );
+        }
+        return NextResponse.json({ success: true }, { headers: rateLimitHeaders });
+      }
+
       const result = await recordInternalAnalyticsEvent(request, internalPayload.data);
       if (!result.ok) {
         return NextResponse.json(

--- a/tests/unit/app/analytics-route.test.ts
+++ b/tests/unit/app/analytics-route.test.ts
@@ -274,6 +274,33 @@ describe("analytics route", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it("acknowledges catalog impressions without persisting passive telemetry", async () => {
+    const insert = vi.fn();
+    mockedGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({ insert }),
+    } as never);
+
+    const response = await POST(
+      request({
+        eventType: "catalog_impression",
+        eventData: {
+          slug: "corporate-clean",
+          rank: 1,
+          surface: "styles_catalog",
+          page: 1,
+          sort: "recommended",
+          collection_slug: null,
+          filter_count: 0,
+          query_present: false,
+        },
+        sessionId: null,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("accepts catalog-backed legacy usage and combinations", async () => {
     const response = await POST(
       request({ slug: "corporate-clean", slugB: "neo-brutalist", source: "api" }),


### PR DESCRIPTION
## What changed\n- stop persisting passive catalog_impression telemetry to Supabase while retaining slug validation and client-side Vercel Analytics\n- add regression coverage for the non-persisting behavior\n\n## Verification\n- 29 targeted analytics tests passed\n- TypeScript check passed\n- production build passed (2181 pages)\n- production PM2 online and homepage responds\n- Supabase analytics_events cleaned to a 7-day retention window\n\n## Operational cleanup\n- removed approximately 968k historical analytics rows older than 7 days\n- removed three unused analytics indexes\n- vacuumed public.analytics_events\n- no auth, user, business, or storage data was modified\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for catalog impression events.
  * Valid impressions are acknowledged without affecting usage metrics.
  * Unknown style references return a clear validation error.

* **Tests**
  * Added coverage confirming valid impressions are accepted without being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->