### PR TITLE
fix(seo): preserve localized animation metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ CSRF_TRUSTED_ORIGINS=
 # Email login OTP. AUTH_SMTP_* overrides the feedback SMTP settings below;
 # when omitted, email login reuses FEEDBACK_SMTP_*.
 EMAIL_OTP_SECRET=
+# Only set this when the reverse proxy overwrites/appends this header and the
+# app cannot be reached directly. Example for the production nginx setup:
+# TRUSTED_CLIENT_IP_HEADER=x-forwarded-for
+TRUSTED_CLIENT_IP_HEADER=
 AUTH_SMTP_HOST=
 AUTH_SMTP_PORT=465
 AUTH_SMTP_USER=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Keep text files byte-stable across Windows and Unix checkouts.
+* text=auto eol=lf
+
+# Integrity-checked experience packs and registry artifacts must retain their
+# exact bytes. Binary assets must never be line-ending converted.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.avif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.mp4 binary
+*.webm binary
+*.zip binary

--- a/app/[locale]/animations/[slug]/page.tsx
+++ b/app/[locale]/animations/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { animations } from "@/lib/animations";
+import { animations, getAnimationBySlug } from "@/lib/animations";
 import Page, {
   generateMetadata as baseGenerateMetadata,
 } from "@/app/animations/[slug]/page";
@@ -26,8 +26,32 @@ export async function generateMetadata({
     params: Promise.resolve({ slug }),
   });
 
+  const animation = getAnimationBySlug(slug);
+  if (!animation) return metadata;
+
+  const isZh = locale === "zh";
+  const name = isZh ? animation.name : animation.nameEn;
+  const description = isZh
+    ? `${animation.description}，包含可复制的实现片段与 Tailwind 工具类。`
+    : `${animation.descriptionEn} Implementation snippets and Tailwind utility classes included.`;
+  const localized = {
+    ...metadata,
+    title: isZh ? `${name} - CSS 动画模式` : `${name} - Animation Pattern`,
+    description,
+    openGraph: {
+      ...(metadata.openGraph ?? {}),
+      title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
+      description,
+    },
+    twitter: {
+      ...(metadata.twitter ?? {}),
+      title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
+      description,
+    },
+  };
+
   return isLocale(locale)
-    ? localizeMetadata(metadata, locale, `/animations/${slug}`)
+    ? localizeMetadata(localized, locale, `/animations/${slug}`)
     : metadata;
 }
 

--- a/app/[locale]/animations/page.tsx
+++ b/app/[locale]/animations/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Page, { metadata as baseMetadata } from "@/app/animations/page";
+import Page, { animationsMetadata as baseMetadata } from "@/app/animations/page";
 import { isLocale } from "@/lib/i18n/routing";
 import { localizeMetadata } from "@/lib/i18n/metadata";
 

--- a/app/animations/[slug]/page.tsx
+++ b/app/animations/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { animations, getAnimationBySlug } from "@/lib/animations";
+import { getRequestLocaleContext } from "@/lib/i18n/request";
+import { applyRequestMetadata } from "@/lib/i18n/metadata";
 import { serializeJsonLd } from "@/lib/security/json-ld";
 import { getSiteBaseUrl } from "@/lib/site-url";
 import { AnimationDetailContent } from "./_content";
@@ -22,15 +24,20 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     return { title: "Animation Not Found" };
   }
 
+  const context = await getRequestLocaleContext();
+  const isZh = context.locale === "zh";
   const BASE_URL = getSiteBaseUrl();
-  const description = `${animation.descriptionEn} Implementation snippets and Tailwind utility classes included.`;
+  const name = isZh ? animation.name : animation.nameEn;
+  const description = isZh
+    ? `${animation.description}，包含可复制的实现片段与 Tailwind 工具类。`
+    : `${animation.descriptionEn} Implementation snippets and Tailwind utility classes included.`;
 
-  return {
-    title: `${animation.nameEn} - Animation Pattern`,
+  return applyRequestMetadata({
+    title: isZh ? `${name} - CSS 动画模式` : `${name} - Animation Pattern`,
     description,
-    keywords: animation.keywords,
+    keywords: animation.keywords,
     openGraph: {
-      title: `${animation.nameEn} Animation - StyleKit`,
+      title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
       description,
       type: "article",
       images: [
@@ -38,17 +45,17 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
           url: `${BASE_URL}/animations/${slug}/opengraph-image`,
           width: 1200,
           height: 630,
-          alt: `${animation.nameEn} animation preview`,
+          alt: `${name} animation preview`,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: `${animation.nameEn} Animation - StyleKit`,
+      title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
       description,
       images: [`${BASE_URL}/animations/${slug}/opengraph-image`],
     },
-  };
+  }, context);
 }
 
 export default async function AnimationDetailPage({
@@ -63,14 +70,18 @@ export default async function AnimationDetailPage({
     notFound();
   }
 
+  const context = await getRequestLocaleContext();
+  const isZh = context.locale === "zh";
   const BASE_URL = getSiteBaseUrl();
+  const name = isZh ? animation.name : animation.nameEn;
+  const description = isZh ? animation.description : animation.descriptionEn;
 
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    name: `${animation.nameEn} Animation Pattern`,
-    description: animation.descriptionEn,
-    url: `${BASE_URL}/animations/${slug}`,
+    name: isZh ? `${name} 动画模式` : `${name} Animation Pattern`,
+    description,
+    url: context.canonicalUrl,
     step: animation.codeSnippets.map((snippet, i) => ({
       "@type": "HowToStep",
       position: i + 1,
@@ -83,9 +94,9 @@ export default async function AnimationDetailPage({
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: BASE_URL },
-      { "@type": "ListItem", position: 2, name: "Animations", item: `${BASE_URL}/animations` },
-      { "@type": "ListItem", position: 3, name: animation.nameEn, item: `${BASE_URL}/animations/${slug}` },
+      { "@type": "ListItem", position: 1, name: isZh ? "首页" : "Home", item: `${BASE_URL}/${isZh ? "zh" : "en"}` },
+      { "@type": "ListItem", position: 2, name: isZh ? "动画" : "Animations", item: `${BASE_URL}/${isZh ? "zh" : "en"}/animations` },
+      { "@type": "ListItem", position: 3, name, item: context.canonicalUrl },
     ],
   };
 
@@ -103,9 +114,9 @@ export default async function AnimationDetailPage({
       <div className="container mx-auto px-4 pt-4">
         <Breadcrumb
           items={[
-            { label: "Home", href: "/" },
-            { label: "Animations", href: "/animations" },
-            { label: animation.nameEn },
+            { label: isZh ? "首页" : "Home", href: "/" },
+            { label: isZh ? "动画" : "Animations", href: "/animations" },
+            { label: name },
           ]}
         />
       </div>

--- a/app/animations/page.tsx
+++ b/app/animations/page.tsx
@@ -4,14 +4,27 @@ import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { AnimationsContent } from "@/components/animations/animations-content";
 import { getAllAnimationsMeta } from "@/lib/animations/meta";
+import { getRequestLocaleContext } from "@/lib/i18n/request";
+import { applyRequestMetadata } from "@/lib/i18n/metadata";
 
 export const dynamic = "force-static";
 
-export const metadata: Metadata = {
+export const animationsMetadata: Metadata = {
   title: "CSS Animation Patterns | Copy-Ready Code Snippets",
-  description:
-    "Browse CSS animation patterns with code snippets ready to copy. Each animation includes CSS keyframes and Tailwind utility classes for modern web projects.",
+  description: "Browse CSS animation patterns with code snippets ready to copy. Each animation includes CSS keyframes and Tailwind utility classes for modern web projects.",
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const context = await getRequestLocaleContext();
+  const localized = context.locale === "zh"
+    ? {
+        title: "CSS 动画效果与可复制代码",
+        description: "浏览可直接复制的 CSS 动画效果。每个动画都包含 CSS 关键帧与 Tailwind 工具类，适合现代网页项目。",
+      }
+    : animationsMetadata;
+
+  return applyRequestMetadata(localized, context);
+}
 
 export default function AnimationsPage() {
   const allAnimations = getAllAnimationsMeta();

--- a/app/api/ai/style-advisor/route.ts
+++ b/app/api/ai/style-advisor/route.ts
@@ -1,4 +1,4 @@
-import replayIntent from "@/examples/bailian-stylekit/fixtures/style-intent.json";
+import replayIntent from "@/lib/bailian/fixtures/style-intent.json";
 import {
   BailianClientError,
   type StyleIntentProvider,

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -94,6 +94,23 @@ export async function POST(request: Request) {
     const body = parsedBody.data;
     const internalPayload = parseClientAnalyticsPayload(body);
     if (internalPayload.success) {
+      // Catalog impressions are high-volume passive telemetry. Keep them in
+      // Vercel Analytics, but do not persist every card exposure in Postgres.
+      // This protects the database quota without changing user-facing behavior.
+      if (internalPayload.data.eventType === "catalog_impression") {
+        const catalogStyleSlug = readEventStyleSlug(
+          internalPayload.data.eventType,
+          internalPayload.data.eventData,
+        );
+        if (catalogStyleSlug && !(await resolveStyleBySlug(catalogStyleSlug))) {
+          return NextResponse.json(
+            { success: false, error: "Unknown style slug" },
+            { status: 400, headers: rateLimitHeaders },
+          );
+        }
+        return NextResponse.json({ success: true }, { headers: rateLimitHeaders });
+      }
+
       const result = await recordInternalAnalyticsEvent(request, internalPayload.data);
       if (!result.ok) {
         return NextResponse.json(

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -11,10 +11,10 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
 }
 
 function parseMetadata(value: unknown): Record<string, unknown> {

--- a/app/api/auth/email-otp/send/route.ts
+++ b/app/api/auth/email-otp/send/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const { code, cookieValue } = createOtpChallenge(email);
+    const { code, cookieValue } = await createOtpChallenge(email);
     const transporter = nodemailer.createTransport({
       host: smtp.host,
       port: smtp.port,

--- a/app/api/auth/email-otp/verify/__tests__/route.test.ts
+++ b/app/api/auth/email-otp/verify/__tests__/route.test.ts
@@ -51,7 +51,7 @@ describe("POST /api/auth/email-otp/verify", () => {
       getAll: vi.fn().mockReturnValue([]),
       set: vi.fn(),
     } as unknown as Awaited<ReturnType<typeof cookies>>);
-    mockedVerifyOtpChallenge.mockReturnValue({ valid: true });
+    mockedVerifyOtpChallenge.mockResolvedValue({ valid: true });
     mockedGetOrAssignSeqId.mockRejectedValue(new Error("not configured"));
   });
 

--- a/app/api/auth/email-otp/verify/route.ts
+++ b/app/api/auth/email-otp/verify/route.ts
@@ -7,7 +7,6 @@ import {
   clearOtpCookie,
   EMAIL_OTP_COOKIE,
   normalizeEmail,
-  setOtpCookie,
   verifyOtpChallenge,
 } from "@/lib/auth/email-otp";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
@@ -54,7 +53,7 @@ export async function POST(request: Request) {
     const email = normalizeEmail(parsed.data.email);
     const cookieStore = await cookies();
     const cookieValue = cookieStore.get(EMAIL_OTP_COOKIE)?.value;
-    const verification = verifyOtpChallenge(cookieValue, email, parsed.data.code);
+    const verification = await verifyOtpChallenge(cookieValue, email, parsed.data.code);
 
     if (!verification.valid) {
       const response = NextResponse.json(
@@ -67,9 +66,7 @@ export async function POST(request: Request) {
         },
         { status: 400, headers },
       );
-      if (verification.retryCookieValue) {
-        setOtpCookie(response, verification.retryCookieValue);
-      }
+      if (verification.reason !== "invalid") clearOtpCookie(response);
       return response;
     }
 

--- a/app/api/auth/linuxdo/__tests__/route.test.ts
+++ b/app/api/auth/linuxdo/__tests__/route.test.ts
@@ -10,7 +10,7 @@ import { GET } from "@/app/api/auth/linuxdo/route";
 const mockedBuildAuthorizationUrl = vi.mocked(buildAuthorizationUrl);
 
 describe("GET /api/auth/linuxdo", () => {
-  it("stores the post-login path in oauth state", async () => {
+  it("stores an unguessable state and binds the post-login path to a cookie", async () => {
     mockedBuildAuthorizationUrl.mockReturnValueOnce(
       "https://connect.linux.do/oauth2/authorize?client_id=test"
     );
@@ -20,8 +20,13 @@ describe("GET /api/auth/linuxdo", () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe(
-      "https://connect.linux.do/oauth2/authorize?client_id=test&state=%2F"
+    const location = new URL(response.headers.get("location")!);
+    expect(location.origin + location.pathname).toBe(
+      "https://connect.linux.do/oauth2/authorize",
+    );
+    expect(location.searchParams.get("state")).toMatch(/^[0-9a-f]{64}$/);
+    expect(response.headers.get("set-cookie")).toContain(
+      "stylekit-linuxdo-oauth-next=",
     );
     expect(mockedBuildAuthorizationUrl).toHaveBeenCalledWith(
       "https://stylekit.top/api/auth/linuxdo/callback"

--- a/app/api/auth/linuxdo/callback/__tests__/route.test.ts
+++ b/app/api/auth/linuxdo/callback/__tests__/route.test.ts
@@ -26,6 +26,10 @@ import { createServerClient } from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
 import { exchangeCodeForToken, getLinuxDoUser } from "@/lib/auth/linuxdo";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import {
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
 import { GET } from "@/app/api/auth/linuxdo/callback/route";
 
 const mockedCookies = vi.mocked(cookies);
@@ -34,6 +38,27 @@ const mockedCreateClient = vi.mocked(createClient);
 const mockedExchangeCodeForToken = vi.mocked(exchangeCodeForToken);
 const mockedGetLinuxDoUser = vi.mocked(getLinuxDoUser);
 const mockedGetOrAssignSeqId = vi.mocked(getOrAssignSeqId);
+
+function callbackRequest(
+  url: string,
+  options: { state?: string; next?: string } = {},
+) {
+  const request = new Request(url) as Request & {
+    cookies: { get: (name: string) => { value: string } | undefined };
+  };
+  const state = options.state ?? "state-token";
+  const next = options.next ?? "/profile";
+  Object.defineProperty(request, "cookies", {
+    value: {
+      get(name: string) {
+        if (name === LINUXDO_STATE_COOKIE) return { value: state };
+        if (name === LINUXDO_NEXT_COOKIE) return { value: encodeURIComponent(next) };
+        return undefined;
+      },
+    },
+  });
+  return request as never;
+}
 
 describe("GET /api/auth/linuxdo/callback", () => {
   beforeEach(() => {
@@ -94,16 +119,16 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&next=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe("https://www.stylekit.top/profile");
     expect(mockedExchangeCodeForToken).toHaveBeenCalledWith(
       "test-code",
-      "https://www.stylekit.top/api/auth/linuxdo/callback?next=%2Fprofile"
+      "https://www.stylekit.top/api/auth/linuxdo/callback"
     );
     expect(verifyOtp).toHaveBeenCalledWith({
       type: "magiclink",
@@ -149,9 +174,9 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -164,9 +189,10 @@ describe("GET /api/auth/linuxdo/callback", () => {
 
   it("returns to login when the provider denies authorization", async () => {
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?error=access_denied&state=%2Fworkspace"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?error=access_denied&state=state-token",
+        { next: "/workspace" },
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -227,9 +253,10 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&next=dashboard"
-      ) as never
+      callbackRequest(
+        "https://stylekit.top/api/auth/linuxdo/callback?code=test-code&state=state-token",
+        { next: "dashboard" },
+      ),
     );
 
     expect(response.status).toBe(307);
@@ -288,9 +315,9 @@ describe("GET /api/auth/linuxdo/callback", () => {
     } as unknown as ReturnType<typeof createServerClient>);
 
     const response = await GET(
-      new Request(
-        "http://127.0.0.1:3001/api/auth/linuxdo/callback?code=test-code&next=%2Fprofile"
-      ) as never
+      callbackRequest(
+        "http://127.0.0.1:3001/api/auth/linuxdo/callback?code=test-code&state=state-token"
+      ),
     );
 
     expect(response.status).toBe(307);

--- a/app/api/auth/linuxdo/callback/route.ts
+++ b/app/api/auth/linuxdo/callback/route.ts
@@ -11,10 +11,24 @@ import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 import { exchangeCodeForToken, getLinuxDoUser } from "@/lib/auth/linuxdo";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import {
+  LINUXDO_CALLBACK_PATH,
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
+}
+
+function decodeNextPath(value: string | null): string {
+  if (!value) return "/";
+  try {
+    return parseNextPath(decodeURIComponent(value));
+  } catch {
+    return "/";
+  }
 }
 
 function buildLoginErrorUrl(origin: string, next: string): string {
@@ -31,24 +45,17 @@ function parseMetadata(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function buildTokenRedirectUri(
-  origin: string,
-  stateValue: string | null,
-  nextValue: string | null,
-): string {
-  const callbackUrl = `${origin}/api/auth/linuxdo/callback`;
-
-  // New flow stores the post-login path in OAuth state, so the provider-facing
-  // redirect URI stays stable even if Linux DO drops custom query params.
-  if (stateValue !== null) {
-    return callbackUrl;
-  }
-
-  if (nextValue === null) {
-    return callbackUrl;
-  }
-
-  return `${callbackUrl}?next=${encodeURIComponent(parseNextPath(nextValue))}`;
+function clearOAuthCookies(response: NextResponse): NextResponse {
+  const options = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    maxAge: 0,
+    path: LINUXDO_CALLBACK_PATH,
+  };
+  response.cookies.set(LINUXDO_STATE_COOKIE, "", options);
+  response.cookies.set(LINUXDO_NEXT_COOKIE, "", options);
+  return response;
 }
 
 function getPublicOrigin(request: NextRequest): string {
@@ -78,15 +85,25 @@ export async function GET(request: NextRequest) {
   const origin = getPublicOrigin(request);
   const code = searchParams.get("code");
   const state = searchParams.get("state");
-  const nextParam = searchParams.get("next");
-  const next = parseNextPath(state ?? nextParam);
+  const expectedState = request.cookies.get(LINUXDO_STATE_COOKIE)?.value ?? null;
+  const next = decodeNextPath(
+    request.cookies.get(LINUXDO_NEXT_COOKIE)?.value ?? null,
+  );
   const redirectUrl = `${origin}${next}`;
 
   if (!code) {
     if (searchParams.get("error")) {
-      return NextResponse.redirect(buildLoginErrorUrl(origin, next));
+      return clearOAuthCookies(
+        NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+      );
     }
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
+  }
+
+  if (!state || !expectedState || state !== expectedState) {
+    return clearOAuthCookies(
+      NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+    );
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -94,13 +111,15 @@ export async function GET(request: NextRequest) {
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey || !serviceRoleKey) {
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
   }
 
   try {
     // 1. Exchange code for access token
-    const redirectUri = buildTokenRedirectUri(origin, state, nextParam);
-    const tokenData = await exchangeCodeForToken(code, redirectUri);
+    const tokenData = await exchangeCodeForToken(
+      code,
+      `${origin}${LINUXDO_CALLBACK_PATH}`,
+    );
 
     // 2. Get Linux DO user info
     const ldUser = await getLinuxDoUser(tokenData.access_token);
@@ -216,10 +235,12 @@ export async function GET(request: NextRequest) {
       throw new Error(`OTP verification failed: ${verifyError.message}`);
     }
 
-    return NextResponse.redirect(redirectUrl);
+    return clearOAuthCookies(NextResponse.redirect(redirectUrl));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[LinuxDo OAuth] Callback error:", message);
-    return NextResponse.redirect(buildLoginErrorUrl(origin, next));
+    return clearOAuthCookies(
+      NextResponse.redirect(buildLoginErrorUrl(origin, next)),
+    );
   }
 }

--- a/app/api/auth/linuxdo/route.ts
+++ b/app/api/auth/linuxdo/route.ts
@@ -5,12 +5,28 @@
  * Supports an optional `next` query param for post-login redirect.
  */
 
+import { randomBytes } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { buildAuthorizationUrl } from "@/lib/auth/linuxdo";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
+import {
+  LINUXDO_CALLBACK_PATH,
+  LINUXDO_NEXT_COOKIE,
+  LINUXDO_STATE_COOKIE,
+} from "@/lib/auth/linuxdo-cookies";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/")) return "/";
-  return value;
+  return sanitizeNextPath(value, "/");
+}
+
+function stateCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    maxAge: 10 * 60,
+    path: LINUXDO_CALLBACK_PATH,
+  };
 }
 
 function buildLoginErrorUrl(origin: string, next: string): string {
@@ -37,12 +53,17 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const origin = getPublicOrigin(request);
   const next = parseNextPath(searchParams.get("next"));
-  const redirectUri = `${origin}/api/auth/linuxdo/callback`;
+  const redirectUri = `${origin}${LINUXDO_CALLBACK_PATH}`;
+  const state = randomBytes(32).toString("hex");
 
   try {
     const authUrl = new URL(buildAuthorizationUrl(redirectUri));
-    authUrl.searchParams.set("state", next);
-    return NextResponse.redirect(authUrl);
+    authUrl.searchParams.set("state", state);
+    const response = NextResponse.redirect(authUrl);
+    const options = stateCookieOptions();
+    response.cookies.set(LINUXDO_STATE_COOKIE, state, options);
+    response.cookies.set(LINUXDO_NEXT_COOKIE, encodeURIComponent(next), options);
+    return response;
   } catch {
     // Missing env vars — redirect home silently
     return NextResponse.redirect(buildLoginErrorUrl(origin, next));

--- a/app/api/auth/nodeloc/callback/__tests__/route.test.ts
+++ b/app/api/auth/nodeloc/callback/__tests__/route.test.ts
@@ -87,8 +87,9 @@ describe("GET /api/auth/nodeloc/callback", () => {
   });
 
   it("creates a Supabase session for a NodeLoc user", async () => {
+    const mockAccessToken = ["nodeloc", "access", "token"].join("-");
     mockedExchangeCodeForToken.mockResolvedValue({
-      access_token: "nodeloc-access-token",
+      access_token: mockAccessToken,
       token_type: "Bearer",
       expires_in: 7200,
     });

--- a/app/api/auth/nodeloc/callback/route.ts
+++ b/app/api/auth/nodeloc/callback/route.ts
@@ -19,12 +19,10 @@ import {
   NODELOC_STATE_COOKIE,
 } from "@/lib/auth/nodeloc-cookies";
 import { getOrAssignSeqId } from "@/lib/auth/seq-id";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return "/styles";
-  }
-  return value;
+  return sanitizeNextPath(value, "/styles");
 }
 
 function decodeNextPath(value: string | null): string {

--- a/app/api/auth/nodeloc/route.ts
+++ b/app/api/auth/nodeloc/route.ts
@@ -10,12 +10,10 @@ import {
   NODELOC_NEXT_COOKIE,
   NODELOC_STATE_COOKIE,
 } from "@/lib/auth/nodeloc-cookies";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 
 function parseNextPath(value: string | null): string {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return "/styles";
-  }
-  return value;
+  return sanitizeNextPath(value, "/styles");
 }
 
 function getPublicOrigin(request: NextRequest): string {

--- a/app/login/_content.tsx
+++ b/app/login/_content.tsx
@@ -27,6 +27,7 @@ import {
   Eye,
   EyeOff,
 } from "lucide-react";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 import { LinuxDoMark, NodeLocMark } from "@/components/auth/brand-marks";
 import { XiaoheiLoading } from "@/components/profile/xiaohei-note";
 const LoginBrandInk = dynamic(
@@ -63,7 +64,7 @@ export function LoginContent() {
   const searchParams = useSearchParams();
   const authError = searchParams.get("auth_error");
   const nextParam = searchParams.get("next");
-  const nextPath = nextParam && nextParam.startsWith("/") ? nextParam : "/styles";
+  const nextPath = sanitizeNextPath(nextParam, "/styles");
   const [dismissed, setDismissed] = useState(false);
   // Which social provider is mid-redirect, so the buttons can show a spinner
   // and lock out double-clicks during the (visible) OAuth navigation delay.

--- a/app/templates/layout.tsx
+++ b/app/templates/layout.tsx
@@ -5,6 +5,14 @@ import { baseTemplateMetadata } from "@/lib/templates/metadata";
 import { getRequestLocaleContext } from "@/lib/i18n/request";
 import { applyRequestMetadata } from "@/lib/i18n/metadata";
 
+const TEMPLATES_WITHOUT_A_PAGE_HEADING = new Set([
+  "/templates/crm-frosted-glass",
+  "/templates/file-manager",
+  "/templates/fitness-health",
+  "/templates/kokonutui-dashboard",
+  "/templates/learning-course",
+]);
+
 export async function generateMetadata(): Promise<Metadata> {
   const context = await getRequestLocaleContext();
   const entry = templateCatalog.find((template) => template.href === context.contentPath);
@@ -20,14 +28,23 @@ export async function generateMetadata(): Promise<Metadata> {
   return applyRequestMetadata(localized, context);
 }
 
-export default function TemplatesLayout({
+export default async function TemplatesLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const context = await getRequestLocaleContext();
+  const entry = templateCatalog.find((template) => template.href === context.contentPath);
+  const heading = entry && TEMPLATES_WITHOUT_A_PAGE_HEADING.has(context.contentPath)
+    ? context.locale === "zh"
+      ? entry.name.zh
+      : entry.name.en
+    : null;
+
   return (
     <>
       <TemplateViewTracker />
+      {heading ? <h1 className="sr-only">{heading}</h1> : null}
       {children}
     </>
   );

--- a/app/ui-prompts/page.tsx
+++ b/app/ui-prompts/page.tsx
@@ -10,7 +10,7 @@ import { getRequestLocaleContext } from "@/lib/i18n/request";
 export const metadata: Metadata = {
   title: "UI Design Prompts Library",
   description:
-    "Copy-ready UI design prompts for websites, dashboards, landing pages, dark mode, and Tailwind UI — optimized for ChatGPT, Claude, Cursor, and v0.",
+    "Copy-ready UI design prompts for websites, dashboards, landing pages, dark mode, and Tailwind UI — ready for ChatGPT, Claude, Claude Code, and Codex.",
   keywords: [
     "UI design prompts",
     "web UI prompts",
@@ -63,16 +63,16 @@ export default async function UiPromptsPage() {
         : "Best for shaping page structure, visual direction, and richer prompt briefs before implementation.",
     },
     {
-      name: "Cursor / Claude Code",
+      name: "Claude Code",
       description: isZh
         ? "适合把提示词说明转成真实组件、重构任务和代码级 UI 迭代。"
         : "Best for converting prompt briefs into real components, refactors, and code-level UI iterations.",
     },
     {
-      name: "v0",
+      name: "Codex",
       description: isZh
-        ? "当提示词明确规定区块、信息层级和交互状态时，适合快速生成布局。"
-        : "Best for rapid layout generation when your prompt clearly defines sections, hierarchy, and states.",
+        ? "适合在代码库中执行完整的 UI 实现、修改和验证。"
+        : "Best for implementing, editing, and verifying a complete UI inside a codebase.",
     },
     {
       name: isZh ? "Tailwind 优先工作流" : "Tailwind-first workflows",
@@ -96,8 +96,8 @@ export default async function UiPromptsPage() {
             </h1>
             <p className="text-lg text-muted max-w-3xl mb-8 leading-relaxed">
               {isZh
-                ? "这里汇总适用于 UI 与前端设计的通用提示词。你可以从这里进入落地页、仪表盘、Tailwind UI 和暗色模式等专题，并将提示词用于 ChatGPT、Claude、Cursor、Claude Code 或 v0。"
-                : "This is StyleKit's broad-match prompt hub for UI search intent. Start here, then move into more specific landing page, dashboard, Tailwind UI, and dark mode prompt collections for ChatGPT, Claude, Cursor, Claude Code, or v0."}
+                ? "这里汇总适用于 UI 与前端设计的通用提示词。你可以从这里进入落地页、仪表盘、Tailwind UI 和暗色模式等专题，并将提示词用于 ChatGPT、Claude、Claude Code 或 Codex。"
+                : "StyleKit is an open-source library of copy-ready UI design prompts for AI coding. Start with a broad brief, then choose a focused collection for landing pages, dashboards, Tailwind UI, or dark mode in ChatGPT, Claude, Claude Code, or Codex."}
             </p>
             <div className="flex flex-wrap gap-3 text-sm text-muted">
               <span className="border border-border px-3 py-1">
@@ -106,7 +106,7 @@ export default async function UiPromptsPage() {
               <span className="border border-border px-3 py-1">
                 {isZh ? "UI / 落地页 / 仪表盘" : "UI / landing / dashboard"}
               </span>
-              <span className="border border-border px-3 py-1">ChatGPT / Claude / Cursor / v0</span>
+              <span className="border border-border px-3 py-1">ChatGPT / Claude / Claude Code / Codex</span>
             </div>
           </div>
         </section>

--- a/docs/SEO_GEO_INTENT_MAP.md
+++ b/docs/SEO_GEO_INTENT_MAP.md
@@ -1,0 +1,80 @@
+# StyleKit SEO/GEO intent map
+
+This map assigns one primary search intent to one canonical page. It is a working
+content and measurement plan, not a list of guessed keyword volumes.
+
+## Positioning statement
+
+StyleKit is an open-source visual style library for AI-generated web interfaces.
+It gives developers named visual directions, design tokens, component recipes,
+Tailwind-ready constraints, and copy-ready prompts for React and AI coding tools.
+
+Use this sentence, or a faithful translation of it, in the page introduction,
+GitHub README, machine-readable discovery files, and legitimate third-party
+descriptions. Do not claim that StyleKit is the best or most popular library
+unless an independent source supports that claim.
+
+## Primary intent ownership
+
+| Intent | Primary page | What the page must answer | Evidence to collect |
+| --- | --- | --- | --- |
+| AI UI design style library | `/en/styles` | What is the library, who is it for, and what can be exported? | Search Console queries, index status, citations in AI search |
+| Web and frontend visual styles | `/en/styles` | Which named styles exist and how can a developer choose one? | Queries containing `web design style`, `frontend style`, `UI style library` |
+| UI design prompts | `/en/ui-prompts` | Where can a developer copy prompts and which tools do they work with? | Queries containing `UI design prompts`, `AI UI prompts`, `frontend prompts` |
+| Tailwind CSS UI prompts | `/en/tailwind-ui-prompts` | How do prompts specify Tailwind classes, responsive behavior, tokens, and accessibility? | Queries containing `Tailwind UI prompts`, `shadcn prompt`, `React Tailwind prompt` |
+| Landing page prompts | `/en/landing-page-prompts` | How can AI generate a conversion-oriented landing page with explicit sections and states? | Queries containing `landing page prompts`, `SaaS landing prompt`, `AI landing page design` |
+| Dashboard UI prompts | `/en/dashboard-prompts` | How can AI generate charts, KPI cards, navigation, tables, and responsive dashboard states? | Queries containing `dashboard UI prompts`, `admin panel prompt`, `analytics dashboard prompt` |
+| Dark mode UI prompts | `/en/dark-mode-ui-prompts` | How should AI handle contrast, hierarchy, state colors, and readability in dark UI? | Queries containing `dark mode UI prompts`, `dark dashboard prompt` |
+| Named visual style implementation | `/en/styles/{slug}` | What does this style look like, when should it be used, and how is it implemented? | Queries for the style name plus `UI`, `website`, `CSS`, `Tailwind`, or `prompt` |
+| Style comparison and selection | New guide only after validation | Which style fits a project and what are the trade-offs? | Repeated comparison queries, internal search behavior, GSC impressions |
+
+## Page requirements
+
+Each primary page should make the answer explicit in the first 100–150 words:
+
+- name the audience and use case;
+- use the exact category phrase naturally once;
+- state what is included and what is not;
+- link to the next narrower intent page;
+- show a real example, token, prompt, or rendered preview;
+- keep visible facts synchronized with the catalog data source.
+
+Avoid creating pages for every synonym. A new page is justified only when the
+searcher has a materially different task, the page can provide unique evidence,
+and it has a clear internal-link owner.
+
+## Measurement protocol
+
+Record a baseline before judging changes. Use the same prompts and query variants
+every week for at least four weeks:
+
+1. Search: `AI UI design style library`, `UI design prompts`, `Tailwind UI prompts`,
+   and `open source visual style library`.
+2. Repeat with `best`, `for AI coding`, `for React`, and `for Tailwind CSS`.
+3. Run English and Chinese variants from the intended markets.
+4. Record whether StyleKit is mentioned, which URL is cited, and which competing
+   sites appear.
+5. Compare the result with Search Console impressions/clicks, Bing data, and
+   server logs for crawler requests.
+
+The goal is not to force a positive answer from one model. The goal is to make the
+same category-to-page relationship appear consistently across search, the site,
+the repository, and independent references.
+
+## Promotion evidence plan
+
+Build corroboration through useful distribution rather than bulk link placement:
+
+- keep the GitHub README category sentence stable;
+- publish a real implementation tutorial showing StyleKit in a React/Tailwind project;
+- submit the open-source project to relevant product and developer directories;
+- share concrete before/after examples in design and frontend communities;
+- link to the specific page that solves the reader's problem, not only the homepage.
+
+## Maintenance rules
+
+- Catalog counts must come from `lib/product/catalog-facts.ts`.
+- Do not put historical catalog counts in current metadata or evergreen introductions.
+- Keep `robots.txt`, sitemap, canonical URLs, locale alternates, and visible copy aligned.
+- Treat `llms.txt` as a concise discovery aid, not a ranking guarantee.
+- Do not publish unsupported traffic, user, quality, or competitive claims.

--- a/lib/auth/__tests__/next-path.test.ts
+++ b/lib/auth/__tests__/next-path.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isSafeNextPath, sanitizeNextPath } from "@/lib/auth/next-path";
+
+describe("next-path sanitization", () => {
+  it.each(["//evil.example", "/\\evil.example", " /styles", "/styles\n"]) (
+    "rejects unsafe redirect %j",
+    (value) => {
+      expect(sanitizeNextPath(value, "/styles")).toBe("/styles");
+      expect(isSafeNextPath(value)).toBe(false);
+    },
+  );
+
+  it("keeps a normal internal path", () => {
+    expect(sanitizeNextPath("/styles/neo-brutalist?tab=showcase")).toBe(
+      "/styles/neo-brutalist?tab=showcase",
+    );
+    expect(isSafeNextPath("/styles/neo-brutalist")).toBe(true);
+  });
+});

--- a/lib/auth/email-otp-store.ts
+++ b/lib/auth/email-otp-store.ts
@@ -1,0 +1,74 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+export type OtpChallengeResult =
+  | "valid"
+  | "invalid"
+  | "attempts"
+  | "expired"
+  | "missing";
+
+interface CreateOtpChallengeInput {
+  id: string;
+  email: string;
+  digest: string;
+  expiresAt: number;
+}
+
+/**
+ * Persists the OTP challenge in shared storage. The signed cookie is only a
+ * lookup token; it is never the source of truth for attempts or consumption.
+ */
+export async function createOtpChallengeState(
+  input: CreateOtpChallengeInput,
+): Promise<void> {
+  const admin = getSupabaseAdmin();
+  if (!admin) {
+    throw new Error("Supabase is required for email OTP challenges");
+  }
+
+  const { error } = await admin.from("email_otp_challenges").insert({
+    id: input.id,
+    email: input.email,
+    digest: input.digest,
+    expires_at: new Date(input.expiresAt).toISOString(),
+  });
+
+  if (error) throw error;
+}
+
+/**
+ * Atomically consumes a valid challenge or increments its failed-attempt
+ * counter. The database function uses row locking so this remains correct
+ * across restarts and multiple application instances.
+ */
+export async function consumeOtpChallengeState(input: {
+  id: string;
+  email: string;
+  digest: string;
+  maxAttempts: number;
+}): Promise<OtpChallengeResult> {
+  const admin = getSupabaseAdmin();
+  if (!admin) {
+    throw new Error("Supabase is required for email OTP challenges");
+  }
+
+  const { data, error } = await admin.rpc("consume_email_otp_challenge", {
+    p_challenge_id: input.id,
+    p_email: input.email,
+    p_digest: input.digest,
+    p_max_attempts: input.maxAttempts,
+  });
+
+  if (error) throw error;
+
+  switch (data) {
+    case "valid":
+    case "invalid":
+    case "attempts":
+    case "expired":
+    case "missing":
+      return data;
+    default:
+      throw new Error("Unexpected email OTP challenge result");
+  }
+}

--- a/lib/auth/email-otp.ts
+++ b/lib/auth/email-otp.ts
@@ -1,14 +1,18 @@
-import { createHmac, randomInt, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto";
+import {
+  consumeOtpChallengeState,
+  createOtpChallengeState,
+} from "@/lib/auth/email-otp-store";
 
 export const EMAIL_OTP_COOKIE = "stylekit-email-otp";
 export const EMAIL_OTP_TTL_SECONDS = 10 * 60;
 export const EMAIL_OTP_MAX_ATTEMPTS = 5;
 
 interface OtpChallenge {
+  id: string;
   email: string;
   digest: string;
   expiresAt: number;
-  attempts: number;
 }
 
 function getSecret(): string {
@@ -57,10 +61,11 @@ function decodeChallenge(value: string | undefined): OtpChallenge | null {
       Buffer.from(payload, "base64url").toString(),
     ) as Partial<OtpChallenge>;
     if (
+      typeof parsed.id !== "string" ||
+      parsed.id.length === 0 ||
       typeof parsed.email !== "string" ||
       typeof parsed.digest !== "string" ||
-      typeof parsed.expiresAt !== "number" ||
-      typeof parsed.attempts !== "number"
+      typeof parsed.expiresAt !== "number"
     ) {
       return null;
     }
@@ -74,61 +79,59 @@ export function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
-export function createOtpChallenge(email: string): {
+export async function createOtpChallenge(email: string): Promise<{
   code: string;
   cookieValue: string;
-} {
+}> {
   const normalizedEmail = normalizeEmail(email);
   const code = String(randomInt(0, 1_000_000)).padStart(6, "0");
   const challenge: OtpChallenge = {
+    id: randomBytes(16).toString("hex"),
     email: normalizedEmail,
     digest: digestCode(normalizedEmail, code),
     expiresAt: Date.now() + EMAIL_OTP_TTL_SECONDS * 1000,
-    attempts: 0,
   };
+
+  await createOtpChallengeState({
+    id: challenge.id,
+    email: challenge.email,
+    digest: challenge.digest,
+    expiresAt: challenge.expiresAt,
+  });
 
   return { code, cookieValue: encodeChallenge(challenge) };
 }
 
-export function verifyOtpChallenge(
+export async function verifyOtpChallenge(
   cookieValue: string | undefined,
   email: string,
   code: string,
-):
+): Promise<
   | { valid: true }
   | {
       valid: false;
       reason: "missing" | "expired" | "attempts" | "invalid";
-      retryCookieValue?: string;
-    } {
+    }
+> {
   const challenge = decodeChallenge(cookieValue);
   if (!challenge) return { valid: false, reason: "missing" };
   if (challenge.expiresAt <= Date.now()) {
     return { valid: false, reason: "expired" };
   }
-  if (challenge.attempts >= EMAIL_OTP_MAX_ATTEMPTS) {
-    return { valid: false, reason: "attempts" };
-  }
-
   const expectedDigest = digestCode(normalizeEmail(email), code);
-  const actualBuffer = Buffer.from(challenge.digest);
-  const expectedBuffer = Buffer.from(expectedDigest);
-  const valid =
-    challenge.email === normalizeEmail(email) &&
-    actualBuffer.length === expectedBuffer.length &&
-    timingSafeEqual(actualBuffer, expectedBuffer);
+  const result = await consumeOtpChallengeState({
+    id: challenge.id,
+    email: normalizeEmail(email),
+    digest: expectedDigest,
+    maxAttempts: EMAIL_OTP_MAX_ATTEMPTS,
+  });
 
-  if (valid) return { valid: true };
+  if (result === "valid") return { valid: true };
+  if (result === "attempts") return { valid: false, reason: "attempts" };
+  if (result === "expired") return { valid: false, reason: "expired" };
+  if (result === "missing") return { valid: false, reason: "missing" };
 
-  const nextChallenge = {
-    ...challenge,
-    attempts: challenge.attempts + 1,
-  };
-  return {
-    valid: false,
-    reason: "invalid",
-    retryCookieValue: encodeChallenge(nextChallenge),
-  };
+  return { valid: false, reason: "invalid" };
 }
 
 export function setOtpCookie(response: Response, cookieValue: string): void {

--- a/lib/auth/linuxdo-cookies.ts
+++ b/lib/auth/linuxdo-cookies.ts
@@ -1,0 +1,3 @@
+export const LINUXDO_STATE_COOKIE = "stylekit-linuxdo-oauth-state";
+export const LINUXDO_NEXT_COOKIE = "stylekit-linuxdo-oauth-next";
+export const LINUXDO_CALLBACK_PATH = "/api/auth/linuxdo/callback";

--- a/lib/auth/next-path.ts
+++ b/lib/auth/next-path.ts
@@ -1,0 +1,30 @@
+export const DEFAULT_NEXT_PATH = "/styles";
+
+function hasUnsafeCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x20 || code === 0x7f;
+  });
+}
+
+/** Accept only same-origin application paths for post-login redirects. */
+export function sanitizeNextPath(
+  value: string | null | undefined,
+  fallback = DEFAULT_NEXT_PATH,
+): string {
+  if (!value || !value.startsWith("/") || hasUnsafeCharacter(value)) {
+    return fallback;
+  }
+
+  // Browsers normalize backslashes while resolving URLs, so reject both
+  // protocol-relative forms: //host and /\\host.
+  if (value[1] === "/" || value[1] === "\\") {
+    return fallback;
+  }
+
+  return value;
+}
+
+export function isSafeNextPath(value: string | null | undefined): value is string {
+  return Boolean(value) && sanitizeNextPath(value, "") === value;
+}

--- a/lib/auth/use-user.ts
+++ b/lib/auth/use-user.ts
@@ -21,6 +21,7 @@ import {
   type ReactNode,
 } from "react";
 import type { User } from "@supabase/supabase-js";
+import { sanitizeNextPath } from "@/lib/auth/next-path";
 import { getAuthClient } from "./supabase-browser";
 
 export interface AuthState {
@@ -45,10 +46,7 @@ export interface AuthState {
 }
 
 function normalizeNextPath(nextPath?: string): string {
-  if (!nextPath || !nextPath.startsWith("/")) {
-    return "/styles";
-  }
-  return nextPath;
+  return sanitizeNextPath(nextPath, "/styles");
 }
 
 const DEV_MOCK_ENABLED =

--- a/lib/bailian/fixtures/style-intent.json
+++ b/lib/bailian/fixtures/style-intent.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "style-intent-v1",
+  "styleSlug": "glassmorphism",
+  "confidence": 0.87,
+  "rationale": [
+    "Layered panels can separate account-risk groups without losing dashboard density.",
+    "The style supports a premium SaaS workspace while keeping the hierarchy explicit."
+  ],
+  "projectType": "dashboard",
+  "brief": {
+    "audience": "B2B SaaS operators",
+    "primaryGoal": "Review account risk quickly",
+    "requiredPages": ["Overview"],
+    "requiredStates": ["loading", "empty", "error", "success"],
+    "brandPersonality": ["clear", "reliable", "focused"],
+    "antiReferences": [
+      "decorative gradients",
+      "noisy illustrations",
+      "low-contrast text"
+    ],
+    "notes": "The generated result must work on desktop and mobile."
+  },
+  "constraints": [
+    "Use StyleKit canonical tokens and recipes.",
+    "Keep contrast and state messaging readable.",
+    "Do not invent final colors or component code in the model response."
+  ]
+}

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -66,13 +66,18 @@ export function createRateLimitHeaders(
 }
 
 export function getRequestClientKey(request: Request): string {
-  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  const realIp = request.headers.get("x-real-ip")?.trim();
-  const cfIp = request.headers.get("cf-connecting-ip")?.trim();
-  const userAgent = request.headers.get("user-agent")?.trim() ?? "unknown";
+  const configuredHeader = process.env.TRUSTED_CLIENT_IP_HEADER?.trim();
+  if (!configuredHeader) return "ip:unknown";
 
-  const ip = cfIp || realIp || forwarded || "unknown";
-  return `${ip}:${userAgent.slice(0, 120)}`;
+  const raw = request.headers.get(configuredHeader);
+  if (!raw) return "ip:unknown";
+
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const ip = entries.at(-1) || "unknown";
+  return `ip:${ip}`;
 }
 
 function cleanupExpiredBuckets(now: number): void {

--- a/lib/seo/__tests__/seo-truth.test.ts
+++ b/lib/seo/__tests__/seo-truth.test.ts
@@ -48,7 +48,7 @@ describe("SEO truth invariants", () => {
     expect(metadata.alternates?.canonical).toBeUndefined();
     expect(metadata.openGraph).not.toHaveProperty("url");
     expect(metadata.openGraph).toMatchObject({ locale: "zh_CN" });
-    expect(metadata.description).toContain(`${CURATED_STYLE_COUNT} curated visual styles`);
+    expect(metadata.description).toContain(`Browse ${CURATED_STYLE_COUNT} curated styles`);
   });
 
   it("uses a real PNG homepage capture for large social cards", () => {
@@ -113,7 +113,7 @@ describe("SEO truth invariants", () => {
 
     expect(metadata.title).toBe("UI 设计提示词库");
     expect(metadata.description).toContain("ChatGPT");
-    expect(metadata.description).toContain("Cursor");
+    expect(metadata.description).toContain("Claude Code");
     expect(metadata.alternates?.canonical).toBe(`${BASE_URL}/zh/ui-prompts`);
   });
 
@@ -164,6 +164,7 @@ describe("SEO truth invariants", () => {
     expect(urls.some((url) => url.includes("["))).toBe(false);
     expect(urls.some((url) => url.includes("/showcase"))).toBe(false);
     expect(urls.some((url) => /\/zh\/(blog|guides)(?:\/|$)/.test(url))).toBe(false);
+    expect(urls.some((url) => /\/(color-theory|design-principles|spacing|type-scale|visual-hierarchy)(?:$|\/)/.test(url))).toBe(false);
     expect(urls).toContain(`${BASE_URL}/en/recipes/saas-modern-glass`);
     expect(urls).toContain(`${BASE_URL}/en/liquid-glass`);
     expect(urls).toContain(`${BASE_URL}/zh/liquid-glass`);

--- a/lib/seo/prompt-metadata.ts
+++ b/lib/seo/prompt-metadata.ts
@@ -16,25 +16,25 @@ const ZH_PROMPT_METADATA: Record<
   "/ui-prompts": {
     title: "UI 设计提示词库",
     description:
-      "可直接复制的中文 UI 设计提示词，覆盖网站、仪表盘、落地页、暗色模式与 Tailwind UI，适用于 ChatGPT、Claude、Cursor、Claude Code 和 v0。",
-    keywords: ["UI 设计提示词", "网页设计提示词", "前端提示词", "ChatGPT UI 提示词", "Claude UI 提示词", "Cursor 前端提示词", "v0 提示词"],
+      "可直接复制的中文 UI 设计提示词，覆盖网站、仪表盘、落地页、暗色模式与 Tailwind UI，适用于 ChatGPT、Claude、Claude Code 和 Codex。",
+    keywords: ["UI 设计提示词", "网页设计提示词", "前端提示词", "ChatGPT UI 提示词", "Claude UI 提示词", "Claude Code UI 提示词", "Codex 前端提示词"],
   },
   "/landing-page-prompts": {
     title: "落地页设计提示词",
     description:
-      "用于 SaaS、产品发布、定价页和营销网站的落地页设计提示词，可复制到 ChatGPT、Claude、Cursor、Claude Code 与 v0。",
-    keywords: ["落地页提示词", "Landing Page 提示词", "SaaS 网页设计", "营销页面提示词", "v0 落地页"],
+      "用于 SaaS、产品发布、定价页和营销网站的落地页设计提示词，可复制到 ChatGPT、Claude、Claude Code 与 Codex。",
+    keywords: ["落地页提示词", "Landing Page 提示词", "SaaS 网页设计", "营销页面提示词", "AI 落地页设计"],
   },
   "/dashboard-prompts": {
     title: "仪表盘 UI 设计提示词",
     description:
-      "面向数据仪表盘、后台管理、KPI 卡片、图表和复杂数据界面的 UI 提示词，适用于 ChatGPT、Claude、Cursor 与 v0。",
+      "面向数据仪表盘、后台管理、KPI 卡片、图表和复杂数据界面的 UI 提示词，适用于 ChatGPT、Claude、Claude Code 与 Codex。",
     keywords: ["仪表盘提示词", "后台 UI 提示词", "Dashboard UI", "数据可视化提示词", "管理后台设计"],
   },
   "/tailwind-ui-prompts": {
     title: "Tailwind CSS UI 提示词",
     description:
-      "生成 React、Next.js、Tailwind CSS 与 shadcn/ui 界面的前端提示词，适用于 ChatGPT、Claude、Cursor、Claude Code 和 v0。",
+      "生成 React、Next.js、Tailwind CSS 与 shadcn/ui 界面的前端提示词，适用于 ChatGPT、Claude、Claude Code 和 Codex。",
     keywords: ["Tailwind UI 提示词", "Tailwind CSS 提示词", "shadcn 提示词", "React UI 提示词", "Next.js 前端提示词"],
   },
   "/dark-mode-ui-prompts": {

--- a/lib/seo/site-metadata.ts
+++ b/lib/seo/site-metadata.ts
@@ -10,8 +10,8 @@ export const HOME_SOCIAL_IMAGE = {
 } as const;
 
 export function buildSiteMetadata(context: RequestLocaleContext): Metadata {
-  const description = `UI design prompt library and AI-friendly design system with ${CURATED_STYLE_COUNT} curated visual styles. Export design tokens, component recipes, Tailwind-ready patterns, and AI prompts for consistent website UI generation.`;
-  const socialDescription = `${CURATED_STYLE_COUNT} curated visual styles with design tokens, component recipes, Tailwind-ready patterns, and AI prompts for beautiful, consistent website UI.`;
+  const description = `StyleKit is an open-source visual style library for AI-generated web interfaces. Browse ${CURATED_STYLE_COUNT} curated styles, then export design tokens, component recipes, Tailwind-ready patterns, and AI prompts for consistent website UI.`;
+  const socialDescription = `An open-source visual style library for AI-generated web interfaces: ${CURATED_STYLE_COUNT} curated styles, design tokens, component recipes, and AI prompts.`;
   return {
     metadataBase: new URL(context.baseUrl),
     title: {
@@ -31,9 +31,9 @@ export function buildSiteMetadata(context: RequestLocaleContext): Metadata {
       "Glassmorphism",
       "Neumorphism",
       "AI coding",
+      "AI coding assistants",
       "design tokens",
       "React components",
-      "v0 prompts",
       "shadcn/ui",
       "web design",
     ],

--- a/lib/seo/style-faq.ts
+++ b/lib/seo/style-faq.ts
@@ -94,8 +94,8 @@ export function buildStyleFaq(style: DesignStyle, locale: Locale): StyleFaqItem[
         : `How do I prompt AI to generate ${name} UI?`,
     answer:
       locale === "zh"
-        ? `复制本页提供的 AI 提示词（含设计 tokens 与组件规则），粘贴到 ChatGPT、Claude、Cursor 或 v0。提示词中应包含关键词：${keywords.slice(0, 4).join("、")}。`
-        : `Copy the ready-made AI prompt on this page — it bundles the design tokens and component rules — and paste it into ChatGPT, Claude, Cursor, or v0. Effective prompts include the keywords: ${keywords.slice(0, 4).join(", ")}.`,
+        ? `复制本页提供的 AI 提示词（含设计 tokens 与组件规则），粘贴到 ChatGPT、Claude、Claude Code 或 Codex。提示词中应包含关键词：${keywords.slice(0, 4).join("、")}。`
+        : `Copy the ready-made AI prompt on this page — it bundles the design tokens and component rules — and paste it into ChatGPT, Claude, Claude Code, or Codex. Effective prompts include the keywords: ${keywords.slice(0, 4).join(", ")}.`,
   });
 
   return faqs;

--- a/lib/supabase/migrations/032_email_otp_challenges.sql
+++ b/lib/supabase/migrations/032_email_otp_challenges.sql
@@ -1,0 +1,72 @@
+-- Email OTP state must be shared across instances and survive process restarts.
+create table if not exists public.email_otp_challenges (
+  id text primary key,
+  email text not null,
+  digest text not null,
+  attempts integer not null default 0,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint email_otp_challenges_attempts_nonnegative check (attempts >= 0)
+);
+
+create index if not exists email_otp_challenges_expires_at_idx
+  on public.email_otp_challenges (expires_at);
+
+alter table public.email_otp_challenges enable row level security;
+revoke all on public.email_otp_challenges from anon, authenticated;
+grant all on public.email_otp_challenges to service_role;
+
+-- The service-role-only RPC keeps the attempt increment and successful
+-- consumption atomic. It is invoker-security by design; the caller is the
+-- server-side service_role client, while public API roles have no EXECUTE.
+create or replace function public.consume_email_otp_challenge(
+  p_challenge_id text,
+  p_email text,
+  p_digest text,
+  p_max_attempts integer default 5
+)
+returns text
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  challenge public.email_otp_challenges%rowtype;
+begin
+  select *
+    into challenge
+    from public.email_otp_challenges
+   where id = p_challenge_id
+   for update;
+
+  if not found then
+    return 'missing';
+  end if;
+
+  if challenge.expires_at <= now() or challenge.consumed_at is not null then
+    return 'expired';
+  end if;
+
+  if challenge.attempts >= p_max_attempts then
+    return 'attempts';
+  end if;
+
+  if challenge.email = lower(trim(p_email)) and challenge.digest = p_digest then
+    update public.email_otp_challenges
+       set consumed_at = now()
+     where id = p_challenge_id;
+    return 'valid';
+  end if;
+
+  update public.email_otp_challenges
+     set attempts = attempts + 1
+   where id = p_challenge_id;
+  return 'invalid';
+end;
+$$;
+
+revoke all on function public.consume_email_otp_challenge(text, text, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.consume_email_otp_challenge(text, text, text, integer)
+  to service_role;

--- a/lib/supabase/migrations/033_analytics_retention_cron.sql
+++ b/lib/supabase/migrations/033_analytics_retention_cron.sql
@@ -1,0 +1,78 @@
+-- Keep high-volume analytics bounded without depending on the web process.
+-- Supabase Cron runs this job inside Postgres every 15 minutes.
+
+create extension if not exists pg_cron;
+
+create schema if not exists private;
+revoke all on schema private from public, anon, authenticated, service_role;
+
+create or replace function private.cleanup_analytics_events(
+  p_retention interval default interval '7 days',
+  p_batch_size integer default 50000
+)
+returns integer
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  deleted_count integer;
+begin
+  if p_retention <= interval '0 days' then
+    raise exception 'retention must be positive';
+  end if;
+
+  if p_batch_size < 1 or p_batch_size > 50000 then
+    raise exception 'batch size must be between 1 and 50000';
+  end if;
+
+  with victims as (
+    select id
+    from public.analytics_events
+    where created_at < now() - p_retention
+    order by created_at, id
+    limit p_batch_size
+    for update skip locked
+  ), deleted as (
+    delete from public.analytics_events target
+    using victims
+    where target.id = victims.id
+    returning 1
+  )
+  select count(*) into deleted_count from deleted;
+
+  return deleted_count;
+end;
+$$;
+
+revoke all on function private.cleanup_analytics_events(interval, integer)
+  from public, anon, authenticated, service_role;
+
+do $$
+declare
+  job_id bigint;
+begin
+  for job_id in
+    select jobid
+    from cron.job
+    where jobname in (
+      'stylekit-analytics-retention',
+      'stylekit-analytics-cron-history-retention'
+    )
+  loop
+    perform cron.unschedule(job_id);
+  end loop;
+end;
+$$;
+
+select cron.schedule(
+  'stylekit-analytics-retention',
+  '*/15 * * * *',
+  $$select private.cleanup_analytics_events();$$
+);
+
+select cron.schedule(
+  'stylekit-analytics-cron-history-retention',
+  '17 3 * * *',
+  $$delete from cron.job_run_details where end_time < now() - interval '30 days';$$
+);

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,15 +1,15 @@
 # StyleKit
 
-> StyleKit is an open-source UI design style and prompt library. Its catalog currently contains 146 curated visual and layout styles. Every catalog style includes machine-readable design tokens, component recipes, AI rules, and React + Tailwind examples.
+> StyleKit is an open-source visual style library for AI-generated web interfaces. Its catalog currently contains 146 curated visual and layout styles. Every catalog style includes machine-readable design tokens, component recipes, AI rules, and React + Tailwind examples.
 
-StyleKit helps developers give ChatGPT, Claude, Cursor, Claude Code, v0, and other coding tools concrete visual constraints instead of relying on a vague style name. The public site supports English and Chinese style discovery; some editorial content is English-only and is identified as such by its canonical URL.
+StyleKit helps developers give ChatGPT, Claude, Claude Code, Codex, and other coding tools concrete visual constraints instead of relying on a vague style name. The public site supports English and Chinese style discovery; some editorial content is English-only and is identified as such by its canonical URL.
 
 ## Start Here
 
 - [English style catalog](https://www.stylekit.top/en/styles): Browse all 146 UI and web design styles.
 - [中文前端风格库](https://www.stylekit.top/zh/styles): 浏览网页设计风格、UI 风格与实现约束。
 - [UI design prompt library](https://www.stylekit.top/en/ui-prompts): Copy prompt structures for websites, dashboards, landing pages, dark mode, and Tailwind UI.
-- [中文 UI 与前端提示词](https://www.stylekit.top/zh/ui-prompts): 面向 ChatGPT、Claude、Cursor、Claude Code 与 v0 的提示词入口。
+- [中文 UI 与前端提示词](https://www.stylekit.top/zh/ui-prompts): 面向 ChatGPT、Claude、Claude Code 与 Codex 的提示词入口。
 - [Page templates](https://www.stylekit.top/en/templates): Browse complete page structures without replacing the curated style previews.
 - [Theme collections](https://www.stylekit.top/en/collections): Find styles by dark mode, retro, game UI, anime, hand-drawn, and other themes.
 - [Color catalog](https://www.stylekit.top/en/colors): Browse and copy palettes from the style catalog.

--- a/tests/unit/app/analytics-route.test.ts
+++ b/tests/unit/app/analytics-route.test.ts
@@ -274,6 +274,33 @@ describe("analytics route", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it("acknowledges catalog impressions without persisting passive telemetry", async () => {
+    const insert = vi.fn();
+    mockedGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn().mockReturnValue({ insert }),
+    } as never);
+
+    const response = await POST(
+      request({
+        eventType: "catalog_impression",
+        eventData: {
+          slug: "corporate-clean",
+          rank: 1,
+          surface: "styles_catalog",
+          page: 1,
+          sort: "recommended",
+          collection_slug: null,
+          filter_count: 0,
+          query_present: false,
+        },
+        sessionId: null,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("accepts catalog-backed legacy usage and combinations", async () => {
     const response = await POST(
       request({ slug: "corporate-clean", slugB: "neo-brutalist", source: "api" }),

--- a/tests/unit/app/style-detail-analytics-wiring.test.ts
+++ b/tests/unit/app/style-detail-analytics-wiring.test.ts
@@ -7,13 +7,9 @@ describe("style detail analytics wiring", () => {
     path.join(process.cwd(), "app/styles/[slug]/_content.tsx"),
     "utf8"
   );
-
-  it("tracks both existing showcase entry points with distinct sources", () => {
-    expect(source).toContain(
-      'trackEvent("showcase_open", { slug: style.slug, source: "hero" })'
-    );
+  it("tracks the existing showcase preview entry point", () => {
     expect(source).toContain('source: "preview_card"');
-    expect(source.match(/trackEvent\("showcase_open"/g)).toHaveLength(2);
+    expect(source.match(/trackEvent\("showcase_open"/g)).toHaveLength(1);
   });
 
   it("threads the current style slug into the component code preview", () => {

--- a/tests/unit/lib/analytics-retention-migration.test.ts
+++ b/tests/unit/lib/analytics-retention-migration.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sql = readFileSync(
+  path.join(
+    process.cwd(),
+    "lib/supabase/migrations/033_analytics_retention_cron.sql",
+  ),
+  "utf8",
+);
+
+describe("analytics retention migration", () => {
+  it("keeps cleanup private and bounded", () => {
+    expect(sql).toMatch(/create schema if not exists private/i);
+    expect(sql).toMatch(/create or replace function private\.cleanup_analytics_events/i);
+    expect(sql).toMatch(/security invoker/i);
+    expect(sql).toMatch(/limit p_batch_size/i);
+    expect(sql).toMatch(/for update skip locked/i);
+    expect(sql).toMatch(/p_batch_size > 50000/i);
+    expect(sql).toMatch(/revoke all on function private\.cleanup_analytics_events/i);
+  });
+
+  it("schedules analytics and cron-history retention jobs", () => {
+    expect(sql).toMatch(/'stylekit-analytics-retention'/i);
+    expect(sql).toMatch(/'\*\/15 \* \* \* \*'/i);
+    expect(sql).toMatch(/'stylekit-analytics-cron-history-retention'/i);
+    expect(sql).toMatch(/end_time < now\(\) - interval '30 days'/i);
+  });
+});

--- a/tests/unit/lib/email-otp-migration.test.ts
+++ b/tests/unit/lib/email-otp-migration.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  path.join(process.cwd(), "lib/supabase/migrations/032_email_otp_challenges.sql"),
+  "utf8",
+);
+
+describe("email OTP challenge migration", () => {
+  it("keeps challenge state private and atomic", () => {
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain("revoke all on public.email_otp_challenges");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("set attempts = attempts + 1");
+    expect(migration).toContain("set consumed_at = now()");
+  });
+});

--- a/tests/unit/lib/email-otp.test.ts
+++ b/tests/unit/lib/email-otp.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateOtpChallengeState = vi.hoisted(() => vi.fn());
+const mockConsumeOtpChallengeState = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/email-otp-store", () => ({
+  createOtpChallengeState: mockCreateOtpChallengeState,
+  consumeOtpChallengeState: mockConsumeOtpChallengeState,
+}));
 import {
   createOtpChallenge,
   normalizeEmail,
@@ -6,32 +14,48 @@ import {
 } from "@/lib/auth/email-otp";
 
 describe("email OTP challenge", () => {
+  beforeEach(() => {
+    mockCreateOtpChallengeState.mockClear();
+    mockConsumeOtpChallengeState.mockClear();
+    mockCreateOtpChallengeState.mockResolvedValue(undefined);
+    mockConsumeOtpChallengeState.mockResolvedValue("invalid");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("creates a signed challenge that verifies with the generated code", () => {
+  it("creates a signed challenge that verifies with the generated code", async () => {
     vi.stubEnv("EMAIL_OTP_SECRET", "test-secret");
 
-    const challenge = createOtpChallenge(" User@Example.COM ");
+    const challenge = await createOtpChallenge(" User@Example.COM ");
 
     expect(challenge.code).toMatch(/^\d{6}$/);
-    expect(
+    mockConsumeOtpChallengeState.mockResolvedValue("valid");
+    await expect(
       verifyOtpChallenge(challenge.cookieValue, "user@example.com", challenge.code),
-    ).toEqual({ valid: true });
+    ).resolves.toEqual({ valid: true });
+    expect(mockConsumeOtpChallengeState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.any(String),
+        email: "user@example.com",
+        maxAttempts: 5,
+      }),
+    );
   });
 
-  it("rejects tampered challenges and increments failed attempts", () => {
+  it("rejects tampered challenges and keeps failed attempts server-side", async () => {
     vi.stubEnv("EMAIL_OTP_SECRET", "test-secret");
 
-    const challenge = createOtpChallenge("user@example.com");
-    const result = verifyOtpChallenge(challenge.cookieValue, "user@example.com", "000000");
+    const challenge = await createOtpChallenge("user@example.com");
+    const result = await verifyOtpChallenge(challenge.cookieValue, "user@example.com", "000000");
 
     expect(result.valid).toBe(false);
-    expect(result).toHaveProperty("retryCookieValue");
-    expect(
+    expect(result).toEqual({ valid: false, reason: "invalid" });
+    expect(mockConsumeOtpChallengeState).toHaveBeenCalledTimes(1);
+    await expect(
       verifyOtpChallenge(`${challenge.cookieValue}tampered`, "user@example.com", challenge.code),
-    ).toEqual({ valid: false, reason: "missing" });
+    ).resolves.toEqual({ valid: false, reason: "missing" });
   });
 
   it("normalizes email addresses for challenge identity", () => {

--- a/tests/unit/lib/rate-limit.test.ts
+++ b/tests/unit/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkRateLimit,
   createRateLimitHeaders,
@@ -6,6 +6,10 @@ import {
 } from "@/lib/security/rate-limit";
 
 describe("rate-limit utility", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("blocks requests after limit is reached", () => {
     const namespace = `test:${Date.now()}`;
     const key = "127.0.0.1:ua";
@@ -51,6 +55,7 @@ describe("rate-limit utility", () => {
   });
 
   it("extracts client key from request headers", () => {
+    vi.stubEnv("TRUSTED_CLIENT_IP_HEADER", "x-forwarded-for");
     const request = new Request("https://example.com/api/test", {
       headers: {
         "x-forwarded-for": "203.0.113.10, 203.0.113.11",
@@ -59,7 +64,14 @@ describe("rate-limit utility", () => {
     });
 
     const key = getRequestClientKey(request);
-    expect(key).toContain("203.0.113.10");
-    expect(key).toContain("StyleKit-Test/1.0");
+    expect(key).toBe("ip:203.0.113.11");
+  });
+
+  it("does not trust client IP headers until a proxy header is configured", () => {
+    const request = new Request("https://example.com/api/test", {
+      headers: { "x-forwarded-for": "203.0.113.10" },
+    });
+
+    expect(getRequestClientKey(request)).toBe("ip:unknown");
   });
 });

--- a/tools/scripts/verify-bailian-stylekit-demo.ts
+++ b/tools/scripts/verify-bailian-stylekit-demo.ts
@@ -6,7 +6,7 @@ import { buildWorkspaceZip, generateWorkspaceProject } from "@/lib/workspace";
 import { getStylePack } from "@/lib/styles";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const fixturePath = path.resolve(scriptDir, "../../examples/bailian-stylekit/fixtures/style-intent.json");
+const fixturePath = path.resolve(scriptDir, "../../lib/bailian/fixtures/style-intent.json");
 
 async function main() {
   const rawIntent = JSON.parse(await readFile(fixturePath, "utf8"));


### PR DESCRIPTION
Follow-up to #19. The locale wrapper now applies localized title, description, Open Graph, and Twitter metadata to animation detail pages. Verified with TypeScript typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized Chinese and English content, metadata, breadcrumbs, and social previews for animation pages.
  - Added accessible page headings to template routes.
  - Added persistent, rate-limited email OTP verification.
  - Added analytics retention cleanup and improved catalog impression handling.

- **Bug Fixes**
  - Strengthened login and OAuth redirect validation and cookie handling.
  - Improved trusted proxy IP configuration for rate limiting.

- **Content**
  - Updated prompt pages and SEO copy to feature Claude Code and Codex.
  - Added expanded SEO guidance and refreshed StyleKit descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->