### PR TITLE
fix(seo): build localized animation metadata directly

### DIFF
--- a/app/[locale]/animations/[slug]/page.tsx
+++ b/app/[locale]/animations/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import { animations, getAnimationBySlug } from "@/lib/animations";
-import Page, {
-  generateMetadata as baseGenerateMetadata,
-} from "@/app/animations/[slug]/page";
+import Page from "@/app/animations/[slug]/page";
 import { isLocale, LOCALES } from "@/lib/i18n/routing";
-import { localizeMetadata } from "@/lib/i18n/metadata";
+import { getLocaleAlternates } from "@/lib/i18n/metadata";
+import { getSiteBaseUrl } from "@/lib/site-url";
 
 export const revalidate = 86400;
+export const dynamicParams = false;
 
 export function generateStaticParams() {
   return LOCALES.flatMap((locale) =>
@@ -22,37 +22,42 @@ export async function generateMetadata({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const { locale, slug } = await params;
-  const metadata = await baseGenerateMetadata({
-    params: Promise.resolve({ slug }),
-  });
-
   const animation = getAnimationBySlug(slug);
-  if (!animation) return metadata;
+  if (!animation || !isLocale(locale)) {
+    return { title: "Animation Not Found" };
+  }
 
   const isZh = locale === "zh";
   const name = isZh ? animation.name : animation.nameEn;
   const description = isZh
     ? `${animation.description}，包含可复制的实现片段与 Tailwind 工具类。`
     : `${animation.descriptionEn} Implementation snippets and Tailwind utility classes included.`;
-  const localized = {
-    ...metadata,
+  const baseUrl = getSiteBaseUrl();
+  const canonical = `${baseUrl}/${locale}/animations/${slug}`;
+  const image = `${baseUrl}/animations/${slug}/opengraph-image`;
+
+  return {
     title: isZh ? `${name} - CSS 动画模式` : `${name} - Animation Pattern`,
     description,
+    keywords: animation.keywords,
+    alternates: {
+      canonical,
+      languages: getLocaleAlternates(`/animations/${slug}`),
+    },
     openGraph: {
-      ...(metadata.openGraph ?? {}),
       title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
       description,
+      url: canonical,
+      type: "article",
+      images: [{ url: image, width: 1200, height: 630, alt: `${name} animation preview` }],
     },
     twitter: {
-      ...(metadata.twitter ?? {}),
+      card: "summary_large_image",
       title: isZh ? `${name} 动画 - StyleKit` : `${name} Animation - StyleKit`,
       description,
+      images: [image],
     },
   };
-
-  return isLocale(locale)
-    ? localizeMetadata(localized, locale, `/animations/${slug}`)
-    : metadata;
 }
 
 export default Page;


### PR DESCRIPTION
Clean-baseline follow-up to #20. The locale animation detail route now generates its own static metadata from route params instead of inheriting root-route metadata through the rewrite layer. TypeScript passed in the source workspace.