### PR TITLE
fix(security): restore per-IP rate-limit key when no proxy header is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,12 @@ CSRF_TRUSTED_ORIGINS=
 # Email login OTP. AUTH_SMTP_* overrides the feedback SMTP settings below;
 # when omitted, email login reuses FEEDBACK_SMTP_*.
 EMAIL_OTP_SECRET=
-# Only set this when the reverse proxy overwrites/appends this header and the
-# app cannot be reached directly. Example for the production nginx setup:
-# TRUSTED_CLIENT_IP_HEADER=x-forwarded-for
+# Header carrying the real client IP for rate limiting. Leave empty behind a
+# plain nginx reverse proxy: the rightmost X-Forwarded-For entry is used, which
+# nginx appends via $proxy_add_x_forwarded_for. Set it only when a CDN publishes
+# the client IP in a different header it overwrites (e.g. cf-connecting-ip behind
+# Cloudflare). Never point it at a header the client can set — the limit keys off
+# its rightmost value.
 TRUSTED_CLIENT_IP_HEADER=
 AUTH_SMTP_HOST=
 AUTH_SMTP_PORT=465

--- a/lib/security/rate-limit.ts
+++ b/lib/security/rate-limit.ts
@@ -65,11 +65,26 @@ export function createRateLimitHeaders(
   };
 }
 
+/**
+ * Identify the caller for rate-limiting.
+ *
+ * Only a proxy-appended value may be trusted. We read the *rightmost* entry of
+ * the chosen header because nginx's `$proxy_add_x_forwarded_for` appends the
+ * real peer to the end — the leftmost entries are client-supplied and forgeable,
+ * so keying on them would let an attacker mint a fresh bucket per request.
+ *
+ * When `TRUSTED_CLIENT_IP_HEADER` is unset we fall back to `x-forwarded-for`,
+ * which the default nginx deployment always appends. Returning a constant here
+ * instead would collapse every visitor into ONE global bucket per namespace,
+ * letting a single actor exhaust it and lock the whole site out of OTP login,
+ * feedback, etc. Only when no forwarding header exists at all (e.g. a direct,
+ * un-proxied hit) do we degrade to a shared "unknown" key.
+ */
 export function getRequestClientKey(request: Request): string {
   const configuredHeader = process.env.TRUSTED_CLIENT_IP_HEADER?.trim();
-  if (!configuredHeader) return "ip:unknown";
+  const headerName = configuredHeader || "x-forwarded-for";
 
-  const raw = request.headers.get(configuredHeader);
+  const raw = request.headers.get(headerName);
   if (!raw) return "ip:unknown";
 
   const entries = raw

--- a/tests/unit/lib/rate-limit.test.ts
+++ b/tests/unit/lib/rate-limit.test.ts
@@ -54,7 +54,7 @@ describe("rate-limit utility", () => {
     expect(Number(headers["retry-after"])).toBeGreaterThan(0);
   });
 
-  it("extracts client key from request headers", () => {
+  it("uses the rightmost entry of the configured proxy header", () => {
     vi.stubEnv("TRUSTED_CLIENT_IP_HEADER", "x-forwarded-for");
     const request = new Request("https://example.com/api/test", {
       headers: {
@@ -63,13 +63,38 @@ describe("rate-limit utility", () => {
       },
     });
 
+    // Rightmost is the proxy-appended peer; leftmost entries are client-forged.
     const key = getRequestClientKey(request);
     expect(key).toBe("ip:203.0.113.11");
   });
 
-  it("does not trust client IP headers until a proxy header is configured", () => {
+  it("falls back to the rightmost X-Forwarded-For entry when no header is configured", () => {
+    // Default deployment (TRUSTED_CLIENT_IP_HEADER unset) must still key per-IP,
+    // not collapse every visitor into one global bucket.
     const request = new Request("https://example.com/api/test", {
-      headers: { "x-forwarded-for": "203.0.113.10" },
+      headers: { "x-forwarded-for": "198.51.100.7, 203.0.113.10" },
+    });
+
+    expect(getRequestClientKey(request)).toBe("ip:203.0.113.10");
+  });
+
+  it("does not let a client forge a fresh key by prepending X-Forwarded-For entries", () => {
+    const attacker = new Request("https://example.com/api/test", {
+      headers: { "x-forwarded-for": "10.0.0.1, 203.0.113.10" },
+    });
+    const attackerAgain = new Request("https://example.com/api/test", {
+      headers: { "x-forwarded-for": "10.0.0.2, 203.0.113.10" },
+    });
+
+    // The forgeable leftmost entry changes, but the proxy-appended rightmost
+    // one is identical, so both land in the same bucket.
+    expect(getRequestClientKey(attacker)).toBe("ip:203.0.113.10");
+    expect(getRequestClientKey(attackerAgain)).toBe("ip:203.0.113.10");
+  });
+
+  it("degrades to a shared key only when no forwarding header exists at all", () => {
+    const request = new Request("https://example.com/api/test", {
+      headers: { "user-agent": "StyleKit-Test/1.0" },
     });
 
     expect(getRequestClientKey(request)).toBe("ip:unknown");


### PR DESCRIPTION
getRequestClientKey returned a constant "ip:unknown" whenever TRUSTED_CLIENT_IP_HEADER was unset — the shipped default in .env.example. That collapses every visitor into one global bucket per namespace, so a single actor could exhaust it (3 requests to /api/auth/email-otp/send) and lock the whole site out of OTP login, feedback, admin-login, etc. for the window. It also contradicted the .env.example comment promising the rightmost X-Forwarded-For entry is used behind plain nginx.

Fall back to x-forwarded-for (rightmost entry, which nginx appends via $proxy_add_x_forwarded_for) when no header is configured, preserving the anti-spoofing property — a client prepending entries cannot mint a fresh bucket. Only a request with no forwarding header at all degrades to the shared "unknown" key. Realign the .env.example comment and add regression tests for the unset-header default and the prepend-forgery case.

## Summary

**What changed:**

**Why:**

## Change Type

- [ ] `feat` — new feature or style
- [ ] `fix` — bug fix
- [ ] `refactor` — code improvement (no behavior change)
- [ ] `docs` — documentation only
- [ ] `chore` — build, CI, or tooling

## Scope

- [ ] Styles / Recipes / Tokens
- [ ] UI Components
- [ ] API Endpoints
- [ ] Templates / Animations
- [ ] Build / CI
- [ ] Documentation

## Style Contribution Checklist

> Skip this section if your PR doesn't add a new style.

- Style slug: `___`
- [ ] Followed [`docs/STYLE_ADDITION_CHECKLIST.md`](docs/STYLE_ADDITION_CHECKLIST.md) completely
- [ ] Created all 6 required files (definition, tokens, recipes, showcase page + content, cover SVG)
- [ ] Updated all 4 registration files (index, meta, recipes/index, style-components)
- [ ] Verified `/styles/<slug>` loads correctly
- [ ] Verified `/styles/<slug>/showcase` renders all 12+ sections
- [ ] Attached screenshots below

## Validation

- [ ] `pnpm run security:secrets` — no secrets detected
- [ ] `pnpm run lint` — no errors
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `pnpm test` — all tests pass
- [ ] `pnpm build` — builds successfully

## Security

- [ ] No secrets, credentials, or `.env` files committed
- [ ] Server-side values are not exposed via `NEXT_PUBLIC_`

## Breaking Changes

- [ ] None
- [ ] Yes (describe below)

## Screenshots

<!-- Attach screenshots or GIFs for any UI changes. Required for style contributions. -->

## Notes for Reviewers

<!-- Key files to review, known risks, follow-up items, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate-limit client identification when requests pass through proxies.
  - Uses the rightmost nonempty `X-Forwarded-For` address by default, while supporting a configured trusted header.
  - Prevents forged leftmost forwarding entries from creating separate rate-limit buckets.
  - Uses a shared fallback key only when no forwarding header is available.

- **Documentation**
  - Clarified trusted client-IP header configuration, proxy/CDN behavior, and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->