### PR TITLE
feat(seo): differentiate hex color pages + deterministic 308

### DIFF
--- a/app/colors/[hex]/page.tsx
+++ b/app/colors/[hex]/page.tsx
@@ -38,23 +38,40 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const hex = detail.hex;
   const styleNames = detail.usedBy.slice(0, 3).map((u) => u.nameEn);
-  const styleClause =
+  // Hex SERPs are zero-click for "conversions" — Google's own color widget
+  // and colorhexa answer that before anyone clicks. What earns the click is
+  // the part they can't show: which Tailwind token it is, which curated UI
+  // styles use it, and what pairs with it. Lead with those (audit #6: ~2,900
+  // impressions/28d across hex queries at ~0% CTR while ranking pos 6-10).
+  const token = detail.tailwind.distance <= 0.05 ? detail.tailwind.token : null;
+  const tokenPrefix = token ? `${hex} (${token})` : hex;
+  const title = styleNames.length
+    ? `${tokenPrefix} — UI styles that use it + pairings`
+    : `${tokenPrefix} — pairings, tints & WCAG contrast`;
+
+  const styleLead =
     styleNames.length > 0
-      ? ` Used by ${styleNames.join(", ")} in the StyleKit library.`
+      ? `Used by ${styleNames.join(", ")}${
+          detail.usedBy.length > styleNames.length
+            ? ` and ${detail.usedBy.length - styleNames.length} more curated styles`
+            : ""
+        }.`
       : "";
+  const description = token
+    ? `${hex} is Tailwind's ${token}. ${styleLead} See colors that pair with it, tints/shades, and WCAG-safe text colors.`.replace("  ", " ").trim()
+    : `${hex}: ${styleLead} RGB/HSL/OKLCH values, tints/shades, palette pairings, and WCAG contrast readings.`.replace("  ", " ").trim();
 
   return canonicalizeEnglishMetadata(
     {
-      title: `${hex} Hex Color — RGB, HSL, OKLCH, Contrast & Tailwind`,
-      description: `${hex} is ${detail.rgbCss} / ${detail.hslCss}. WCAG contrast on white is ${detail.contrast[0].ratio}:1, nearest Tailwind token is ${detail.tailwind.token}.${styleClause}`,
+      title,
+      description,
       keywords: [
         `${hex} color`,
-        `${hex} rgb`,
-        `${hex} hsl`,
         `${hex} tailwind`,
+        `${hex} pairings`,
+        `${hex} palette`,
         `${hex} contrast`,
-        "hex color info",
-        "color palette",
+        "hex color ui",
       ],
     },
     `/colors/${hexToSlug(hex)}`

--- a/proxy.ts
+++ b/proxy.ts
@@ -46,6 +46,13 @@ function shouldRefreshAuthSession(pathname: string): boolean {
   return pathname !== "/api/analytics";
 }
 
+function isPrefetchRequest(request: NextRequest): boolean {
+  return (
+    request.headers.has("next-router-prefetch") ||
+    request.headers.get("purpose") === "prefetch"
+  );
+}
+
 function isSupabaseAuthCookie(name: string): boolean {
   // @supabase/ssr appends .0, .1, ... when a session is split across cookies.
   return name.startsWith("sb-") && /-auth-token(?:\.\d+)?$/.test(name);
@@ -64,6 +71,7 @@ function buildAdminLoginRedirect(request: NextRequest) {
 
 export async function proxy(request: NextRequest) {
   const incomingPath = request.nextUrl.pathname;
+  const prefetchRequest = isPrefetchRequest(request);
   const localeInPath = getLocaleFromPathname(incomingPath);
   const strippedPath = localeInPath
     ? stripLocaleFromPathname(incomingPath)
@@ -77,6 +85,29 @@ export async function proxy(request: NextRequest) {
     const redirectUrl = request.nextUrl.clone();
     redirectUrl.pathname = strippedPath;
     return NextResponse.redirect(redirectUrl);
+  }
+
+  if (
+    !localeInPath &&
+    !shouldBypassLocale(incomingPath) &&
+    effectivePath.startsWith("/colors")
+  ) {
+    // Unprefixed /colors/* has no language-negotiated value for crawlers:
+    // Googlebot (no cookie, no Accept-Language) saw both /en/ and /zh/ as
+    // 307 targets on different crawls and keeps the unprefixed URL indexed
+    // as a locale selector, splitting impressions between /colors/x and
+    // /en/colors/x. Answer language-less requests with a deterministic
+    // permanent redirect; humans with a language preference keep the 307
+    // negotiation below.
+    const ua = request.headers.get("user-agent") || "";
+    const hasLanguagePreference =
+      isLocale(localeCookieValue) ||
+      Boolean(request.headers.get("accept-language"));
+    if (!isSocialCrawler(ua) && !hasLanguagePreference) {
+      const permanentUrl = request.nextUrl.clone();
+      permanentUrl.pathname = addLocaleToPathname(incomingPath, DEFAULT_LOCALE);
+      return NextResponse.redirect(permanentUrl, 308);
+    }
   }
 
   if (!localeInPath && !shouldBypassLocale(incomingPath)) {
@@ -181,7 +212,7 @@ export async function proxy(request: NextRequest) {
 
   if (isAdminRequest && hasAdminPasswordSession) {
     const response = buildResponse();
-    if (localeInPath) {
+    if (localeInPath && !prefetchRequest) {
       response.cookies.set(LOCALE_COOKIE_NAME, localeInPath, {
         path: "/",
         sameSite: "lax",
@@ -196,7 +227,7 @@ export async function proxy(request: NextRequest) {
     process.env.ADMIN_DEV_BYPASS === "true";
   if (isAdminRequest && hasAdminDevBypass) {
     const response = buildResponse();
-    if (localeInPath) {
+    if (localeInPath && !prefetchRequest) {
       response.cookies.set(LOCALE_COOKIE_NAME, localeInPath, {
         path: "/",
         sameSite: "lax",
@@ -219,7 +250,7 @@ export async function proxy(request: NextRequest) {
     }
 
     const response = buildResponse();
-    if (localeInPath) {
+    if (localeInPath && !prefetchRequest) {
       response.cookies.set(LOCALE_COOKIE_NAME, localeInPath, {
         path: "/",
         sameSite: "lax",
@@ -231,7 +262,7 @@ export async function proxy(request: NextRequest) {
 
   if (!isAdminRequest && !shouldRefreshAuthSession(effectivePath)) {
     const response = buildResponse();
-    if (localeInPath) {
+    if (localeInPath && !prefetchRequest) {
       response.cookies.set(LOCALE_COOKIE_NAME, localeInPath, {
         path: "/",
         sameSite: "lax",
@@ -289,7 +320,7 @@ export async function proxy(request: NextRequest) {
     return buildAdminLoginRedirect(request);
   }
 
-  if (localeInPath) {
+  if (localeInPath && !prefetchRequest) {
     supabaseResponse.cookies.set(LOCALE_COOKIE_NAME, localeInPath, {
       path: "/",
       sameSite: "lax",

--- a/proxy.ts
+++ b/proxy.ts
@@ -34,6 +34,16 @@ function isSocialCrawler(userAgent: string): boolean {
   return SOCIAL_CRAWLER_RE.test(userAgent);
 }
 
+// Search and AI crawlers fetch without cookies or Accept-Language, so locale
+// negotiation can never learn anything about them; they need the deterministic
+// answer instead.
+const SEARCH_BOT_RE =
+  /Googlebot|Google-InspectionTool|bingbot|Baiduspider|YandexBot|DuckDuckBot|Slurp|GPTBot|OAI-SearchBot|ChatGPT-User|PerplexityBot|ClaudeBot|Amazonbot|Applebot/i;
+
+function isSearchBot(userAgent: string): boolean {
+  return SEARCH_BOT_RE.test(userAgent);
+}
+
 function isAdminRoute(pathname: string): boolean {
   return pathname === "/admin" || pathname.startsWith("/admin/");
 }
@@ -90,20 +100,17 @@ export async function proxy(request: NextRequest) {
   if (
     !localeInPath &&
     !shouldBypassLocale(incomingPath) &&
-    effectivePath.startsWith("/colors")
+    (effectivePath === "/colors" || effectivePath.startsWith("/colors/"))
   ) {
     // Unprefixed /colors/* has no language-negotiated value for crawlers:
     // Googlebot (no cookie, no Accept-Language) saw both /en/ and /zh/ as
     // 307 targets on different crawls and keeps the unprefixed URL indexed
     // as a locale selector, splitting impressions between /colors/x and
-    // /en/colors/x. Answer language-less requests with a deterministic
-    // permanent redirect; humans with a language preference keep the 307
-    // negotiation below.
+    // /en/colors/x. Answer crawler requests with a deterministic permanent
+    // redirect; humans keep the 307 negotiation below even without a
+    // language preference, so their choice is never pinned permanently.
     const ua = request.headers.get("user-agent") || "";
-    const hasLanguagePreference =
-      isLocale(localeCookieValue) ||
-      Boolean(request.headers.get("accept-language"));
-    if (!isSocialCrawler(ua) && !hasLanguagePreference) {
+    if (isSearchBot(ua)) {
       const permanentUrl = request.nextUrl.clone();
       permanentUrl.pathname = addLocaleToPathname(incomingPath, DEFAULT_LOCALE);
       return NextResponse.redirect(permanentUrl, 308);
@@ -139,11 +146,15 @@ export async function proxy(request: NextRequest) {
     const redirectUrl = request.nextUrl.clone();
     redirectUrl.pathname = addLocaleToPathname(incomingPath, preferredLocale || DEFAULT_LOCALE);
     const response = NextResponse.redirect(redirectUrl);
-    response.cookies.set(LOCALE_COOKIE_NAME, preferredLocale || DEFAULT_LOCALE, {
-      path: "/",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24 * 365,
-    });
+    // A prefetch carries no user intent; letting it write the locale cookie
+    // could silently pin the visitor's language from a background request.
+    if (!prefetchRequest) {
+      response.cookies.set(LOCALE_COOKIE_NAME, preferredLocale || DEFAULT_LOCALE, {
+        path: "/",
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24 * 365,
+      });
+    }
     return response;
   }
 

--- a/tests/unit/proxy-auth.test.ts
+++ b/tests/unit/proxy-auth.test.ts
@@ -106,3 +106,73 @@ describe("proxy Supabase session refresh", () => {
     expect(response.headers.get("location")).toContain("/admin-login");
   });
 });
+
+describe("proxy locale negotiation for /colors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+    mocks.verifyAdminSessionCookieValue.mockResolvedValue(false);
+    mocks.getClaims.mockResolvedValue({
+      data: null,
+      error: null,
+    });
+  });
+
+  function requestWith(pathname: string, headers: Record<string, string>) {
+    return new NextRequest(`https://www.stylekit.top${pathname}`, {
+      headers,
+    });
+  }
+
+  it("answers search bots on unprefixed /colors paths with a permanent redirect", async () => {
+    const response = await proxy(
+      requestWith("/colors/22c55e", {
+        "user-agent":
+          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      }),
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://www.stylekit.top/en/colors/22c55e",
+    );
+  });
+
+  it("keeps language-less humans on temporary negotiation instead of pinning them", async () => {
+    const response = await proxy(
+      requestWith("/colors/22c55e", {
+        "user-agent": "Mozilla/5.0 (Macintosh) regular-browser",
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://www.stylekit.top/en/colors/22c55e",
+    );
+  });
+
+  it("only matches the /colors path segment, not longer prefixes", async () => {
+    const response = await proxy(
+      requestWith("/colorscheme-guide", {
+        "user-agent":
+          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      }),
+    );
+
+    expect(response.status).not.toBe(308);
+  });
+
+  it("does not let a prefetch write the locale cookie", async () => {
+    const response = await proxy(
+      requestWith("/styles", {
+        "user-agent": "Mozilla/5.0 (Macintosh) regular-browser",
+        "next-router-prefetch": "1",
+        cookie: "stylekit-locale=zh",
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #31. Hex queries are the biggest wasted surface (~2,900 imp/28d at ~0% CTR, pos 6-10). New metadata leads with the Tailwind token + curated styles instead of zero-click conversions; language-less (bot) requests get a deterministic 308 to /en/ so Google stops indexing /colors/x as a separate locale-selector URL. Humans keep the 307 negotiation. Deployed and verified live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **SEO Improvements**
  - Color detail pages now feature more relevant titles, descriptions, and keywords based on matching Tailwind tokens, curated UI styles, color pairings, tints, and accessibility contrast information.
  - Search and AI crawlers receive permanent redirects to localized color URLs, improving indexing of color pages.

- **Localization**
  - Regular browsers receive temporary redirects for unlocalized color URLs without having their locale preference pinned.
  - Locale preferences are no longer set during framework prefetch requests.
  - Color URL matching now avoids unrelated paths with similar prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->