### PR TITLE
fix(seo): render color tint/shade swatches as non-links

### DIFF
--- a/app/colors/[hex]/page.tsx
+++ b/app/colors/[hex]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
@@ -94,6 +93,28 @@ function SwatchLink({ hex }: { hex: string }) {
         {hex}
       </span>
     </LocalizedLink>
+  );
+}
+
+/**
+ * Non-interactive swatch for computed color ladders.
+ *
+ * Tints and shades come from a lightness ladder (buildLadder), not the curated
+ * library, so a detail page almost never exists for them. Rendering them as
+ * links pointed every color page at ~8 hard 404s (dynamicParams=false), which
+ * fed Google's "Not found (404)" pile. They are illustrative color math, so
+ * they render as plain swatches. Only neighbors — which are drawn from
+ * getAllDetailSwatches() and always exist — stay clickable via SwatchLink.
+ */
+function Swatch({ hex }: { hex: string }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span
+        className="block h-14 w-full border border-white/10"
+        style={{ backgroundColor: hex }}
+      />
+      <span className="font-mono text-[11px] text-white/50">{hex}</span>
+    </div>
   );
 }
 
@@ -282,10 +303,10 @@ export default async function ColorDetailPage({ params }: PageProps) {
             />
             <div className="grid grid-cols-4 gap-3 md:grid-cols-8 md:gap-4">
               {[...detail.tints].reverse().map((hex) => (
-                <SwatchLink key={`tint-${hex}`} hex={hex} />
+                <Swatch key={`tint-${hex}`} hex={hex} />
               ))}
               {detail.shades.map((hex) => (
-                <SwatchLink key={`shade-${hex}`} hex={hex} />
+                <Swatch key={`shade-${hex}`} hex={hex} />
               ))}
             </div>
             <p className="mt-4 max-w-2xl text-sm leading-[1.75] text-white/50">
@@ -325,12 +346,12 @@ export default async function ColorDetailPage({ params }: PageProps) {
             <p className="mt-4 max-w-2xl text-sm leading-[1.75] text-white/50">
               Paste this into ChatGPT, Claude, Cursor, or v0 to use {detail.hex}
               {" "}with correct contrast constraints.{" "}
-              <Link
+              <LocalizedLink
                 href="/colors"
                 className="text-[#7aa2ff] hover:text-white/90"
               >
                 Browse all palette colors
-              </Link>
+              </LocalizedLink>
               .
             </p>
           </section>


### PR DESCRIPTION
## Summary

**What changed:** On the `/colors/[hex]` detail page, the "Tints and shades" ladder rendered each computed swatch as a clickable `SwatchLink`. Those hexes come from `buildLadder()` (computed lightness steps), not the curated library, so a detail page almost never exists for them and `dynamicParams = false` hard-404s the target. Every one of the ~491 color pages therefore linked to ~8 pages that 404. This makes tints/shades render as plain, non-interactive `Swatch`es instead; neighbors (drawn from `getAllDetailSwatches()`, always real pages) stay clickable. Also fixes one raw unprefixed `<Link href="/colors">` → `LocalizedLink`.

**Why:** Google Search Console flagged a growing "Not found (404)" pile (105 URLs). Root cause was these self-inflicted dead links feeding Googlebot ~8 nonexistent color URLs per page (and the discovered/crawled-not-indexed backlog). Removing the links stops the site from emitting them; the orphaned URLs then drop out of the index over time.

## Change Type

- [x] `fix` — bug fix

## Scope

- [x] Styles / Recipes / Tokens (programmatic `/colors/[hex]` page)

## Validation

Verified on the identical change (same diff) and against **live production** after an isolated hotfix deploy:

- [x] `pnpm run security:secrets` — clean
- [x] `pnpm run lint` — no errors on the changed file
- [x] `npx tsc --noEmit` — no type errors
- [x] `pnpm build` — builds; local `next start` smoke test confirmed the 8 tint/shade hexes are no longer `<a>` links and neighbors remain linked
- [x] Live prod verified: `/en/colors/2563eb` → 200, tint/shade dead links gone (now plain swatches), neighbor links intact, no regressions on `/`, `/en/styles/*`, `/en/community`

> Note: the full `pnpm test` suite currently has pre-existing failures on unrelated WIP files (developer-toolkit, community-seo, no-emoji) that are **not** part of this branch — this branch is a clean cherry-pick onto `main` touching only `app/colors/[hex]/page.tsx`. CI will run the suite on the clean base.

## Security

- [x] No secrets, credentials, or `.env` files committed
- [x] No `NEXT_PUBLIC_` exposure

## Breaking Changes

- [x] None

## Notes for Reviewers

- Single file: `app/colors/[hex]/page.tsx` (+26/-5).
- `main`'s version of this file differs from the deployed branch **only** in `generateMetadata`; the edited regions (imports, `SwatchLink`, tints/shades usage, raw `<Link>`) are byte-identical, so the cherry-pick applied cleanly.
- The fix is **already live on production** (deployed as an isolated hotfix); this PR lands it in `main` so a future deploy from `main` doesn't regress it.
- Follow-up (not in this PR): GSC still shows 1 "Redirect error" + 1 "Server error (5xx)" — single orphan URLs, negligible impact, pending the example URLs from the GSC report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tints and shades no longer link to unavailable color detail pages.
  - Updated the “Browse all palette colors” link to preserve localized navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->