### PR TITLE
feat(seo): link style pages to prompt libraries for internal authority

### DIFF
--- a/app/styles/[slug]/_content.tsx
+++ b/app/styles/[slug]/_content.tsx
@@ -425,6 +425,29 @@ export function StyleDetailContent({
             keywordsEn={style.keywordsEn}
             specTokens={specTokens}
           />
+          <p className="mt-8 text-sm text-muted">
+            {locale === "zh" ? "更多提示词库：" : "More prompt libraries: "}
+            <LocalizedLink
+              href="/ui-prompts"
+              className="underline underline-offset-4 hover:text-foreground transition-colors"
+            >
+              {locale === "zh" ? "全部 UI 提示词" : "All UI Prompts"}
+            </LocalizedLink>
+            {" · "}
+            <LocalizedLink
+              href="/tailwind-ui-prompts"
+              className="underline underline-offset-4 hover:text-foreground transition-colors"
+            >
+              {locale === "zh" ? "Tailwind UI 提示词" : "Tailwind UI Prompts"}
+            </LocalizedLink>
+            {" · "}
+            <LocalizedLink
+              href="/dark-mode-ui-prompts"
+              className="underline underline-offset-4 hover:text-foreground transition-colors"
+            >
+              {locale === "zh" ? "暗色模式提示词" : "Dark Mode UI Prompts"}
+            </LocalizedLink>
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

**What changed:** Adds a muted "More prompt libraries" line to the AI Implementation (`#style-prompts`) section of every style detail page, linking to `/ui-prompts`, `/tailwind-ui-prompts`, and `/dark-mode-ui-prompts`.

**Why:** The `dark-mode-ui-prompts` and `tailwind-ui-prompts` pages sit on page 2 (pos ~12) and are declining (−47% / −64% over 28 days per GSC). The prompt-cluster cross-links (`PromptClusterLinks`) and the footer `/ui-prompts` hub link already exist and weren't enough. The missing lever is direct internal links from the site's strongest, topically relevant indexed pages. Style detail pages (~146 styles × 2 locales) are exactly that — indexed, ranking, and topically adjacent (they *are* the styles these prompts implement). This passes authority one hop to the two stranded pages, the most realistic structural push toward page 1.

## Change Type

- [x] `feat` — SEO / internal linking

## Scope

- [x] UI Components (style detail template — `app/styles/[slug]/_content.tsx`)

## Validation

- [x] `pnpm build` — succeeds; BUILD_ID `3ngJ0DcJ3OpEOp3-kK5JI`
- [x] Links render on **en and zh** style pages with correct locale-prefixed hrefs (`/en/tailwind-ui-prompts`, `/en/dark-mode-ui-prompts`, `/en/ui-prompts`)
- [x] Playwright screenshot — tasteful placement below the Hard Prompt panel, muted 14px, matches existing muted-link pattern (no layout change, no AI-slop)
- [x] Regression: `/styles` index and style pages unchanged (200)
- [x] Deployed to production (isolated) and live-verified on `/en/styles/*` and `/zh/styles/*`

## Security

- [x] No secrets or `NEXT_PUBLIC_` exposure

## Breaking Changes

- [x] None

## Notes for Reviewers

- Single file, +23 lines: one `<p className="mt-8 text-sm text-muted">` with three `LocalizedLink`s, inserted after `AiImplementationPanel`.
- Already deployed to production as an isolated hotfix; this PR lands it in `main`.
- Follow-up (manual, not code): in GSC, "Request Indexing" for `/en/dark-mode-ui-prompts` and `/en/tailwind-ui-prompts` to trigger a re-crawl so the new internal links are picked up sooner.
- Impact is gradual — internal links are a real but slow authority lever; expect movement over weeks, not days.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized navigation links below the AI implementation panel for:
    - All UI prompts
    - Tailwind UI prompts
    - Dark-mode UI prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->