### PR TITLE
docs(reach): align the wave3 copy pack with published package versions

### DIFF
--- a/docs/WAVE3_COMMUNITY_LAUNCH.md
+++ b/docs/WAVE3_COMMUNITY_LAUNCH.md
@@ -6,7 +6,7 @@
 > text across platforms (dedup / 灌水 detection). Prepared 2026-09-06.
 >
 > Facts: repo https://github.com/AnxForever/stylekit (458 stars), site https://stylekit.top,
-> npm `stylekit-mcp@0.2.5` / `stylekit-cli@0.1.3` / `stylekit-core@1.0.0-beta.4`,
+> npm `stylekit-mcp@0.2.5` / `stylekit-cli@0.1.4` / `stylekit-core@1.0.0-beta.3`,
 > 148 curated styles, EN + 中文, MIT. MCP Registry namespace: `io.github.AnxForever/stylekit-mcp`.
 
 ---


### PR DESCRIPTION
## Summary

**What changed:** one line in `docs/WAVE3_COMMUNITY_LAUNCH.md` — the facts line now quotes the actual published versions (`stylekit-cli@0.1.4`, `stylekit-core@1.0.0-beta.3`), verified against the npm registry before any community posts go out.

**Why:** the pack is the source for soon-to-be-published community posts; stale version strings would break the install commands we advertise.

## Change Type
- [x] `docs` — documentation only

## Validation
- [x] Versions cross-checked against `npm view stylekit-cli version` / `npm view stylekit-core version` today.

## Breaking Changes
- [x] None